### PR TITLE
Make the PR template descriptions not comments

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,9 @@
 ## What Changed?
 
-<!-- 
 A summary of what you are proposing to change.
--->
 
 ## Why Does It Need To?
 
-<!-- 
 Describe the concern this change addresses. 
 
 Reference any issues that are related and use closing words such as "fixes" or
@@ -16,7 +13,6 @@ You can find out more about closing words here:
 https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
 
 Try to make your PR about one single concern or issue, unless they are mutually dependent.
--->
 
 ## Checklist
 


### PR DESCRIPTION
## What Changed?

This removes the comment tags from the PR template.

## Why Does It Need To?

This is to encourage the submitter of the PR to overwrite the description so it won't show up in the final, squashed commit message.

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [x] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [x] Documentation in Notion has been updated
- [x] Tests for new behaviors are provided
  - [x] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.