### PR TITLE
Fix Diagnostic Assertion Macros

### DIFF
--- a/crates/dfcheck/src/context.rs
+++ b/crates/dfcheck/src/context.rs
@@ -24,8 +24,8 @@ type FlowsTo = HashMap<Identifier, CtrlFlowsTo>;
 /// Check the condition and emit a [`Context::error`] if it fails.
 #[macro_export]
 macro_rules! assert_error {
-    ($ctx:expr, $cond: expr, $msg:expr) => {
-        if $cond {
+    ($ctx:expr, $cond: expr, $msg:expr $(,)?) => {
+        if !$cond {
             $ctx.error($msg);
         }
     };
@@ -34,8 +34,8 @@ macro_rules! assert_error {
 /// Check the condition and emit a [`Context::warning`] if it fails.
 #[macro_export]
 macro_rules! assert_warning {
-    ($ctx:expr, $cond: expr, $msg:expr) => {
-        if $cond {
+    ($ctx:expr, $cond: expr, $msg:expr $(,)?) => {
+        if !$cond {
             $ctx.warning($msg);
         }
     };


### PR DESCRIPTION
## What Changed?

In had the conditions wrong in the assertion macros. Also now they accept an optional trailing `,` in accordance with the typical macro behavior of e.g. `print`.

## Why Does It Need To?

The assertion macros were unintuitive.

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [x] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [x] Documentation in Notion has been updated
- [x] Tests for new behaviors are provided
  - [x] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.