### PR TITLE
Build test policies in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,6 +46,10 @@ jobs:
         cargo test -p dfpp --test new_alias_analysis_tests
         cargo test -p dfpp --test async_tests
         cargo test -p dfpp --test inline_elision_tests
+    - name: Build Test Policies
+      run: |
+        cd props
+        cargo build --verbose
 
   intergration-tests:
     name: Integration Tests


### PR DESCRIPTION
## What Changed?

Adds a build step for `props` in `rust.yml`

## Why Does It Need To?

Before you could make breaking changes to the interface of our crates. Now at least we'll see them in the test properties.

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [x] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [ ] Documentation in Notion has been updated
- [ ] Tests for new behaviors are provided
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.