### PR TITLE
Fix the names of env variables

### DIFF
--- a/crates/paralegal-flow/src/args.rs
+++ b/crates/paralegal-flow/src/args.rs
@@ -44,7 +44,7 @@ impl Args {
                 },
         } = value;
         let mut dump: DumpArgs = dump.into();
-        if let Ok(from_env) = std::env::var("PARABLE_DUMP") {
+        if let Ok(from_env) = std::env::var("PARALEGAL_DUMP") {
             let from_env = DumpArgs::from_str(&from_env, false)?;
             dump.0 |= from_env.0;
         }
@@ -74,7 +74,7 @@ impl Args {
 #[derive(serde::Serialize, serde::Deserialize, clap::Args)]
 struct GArgs<DA: clap::FromArgMatches + clap::Args> {
     /// Print additional logging output (up to the "info" level)
-    #[clap(short, long, env = "PARABLE_VERBOSE")]
+    #[clap(short, long, env = "PARALEGAL_VERBOSE")]
     verbose: bool,
     /// Print additional logging output (up to the "debug" level).
     ///
@@ -82,18 +82,18 @@ struct GArgs<DA: clap::FromArgMatches + clap::Args> {
     /// output globally. You may instead pass the name of a specific target
     /// function and then only during analysis of that function the debug output
     /// is enabled.
-    #[clap(long, env = "PARABLE_DEBUG")]
+    #[clap(long, env = "PARALEGAL_DEBUG")]
     debug: bool,
-    #[clap(long, env = "PARABLE_DEBUG_TARGET")]
+    #[clap(long, env = "PARALEGAL_DEBUG_TARGET")]
     debug_target: Option<String>,
     /// Where to write the resulting forge code to (defaults to `analysis_result.frg`)
     #[clap(long, default_value = "analysis_result.frg")]
     result_path: std::path::PathBuf,
     /// Emit warnings instead of aborting the analysis on sanity checks
-    #[clap(long, env = "PARABLE_RELAXED")]
+    #[clap(long, env = "PARALEGAL_RELAXED")]
     relaxed: bool,
 
-    #[clap(long, env = "PARABLE_TARGET")]
+    #[clap(long, env = "PARALEGAL_TARGET")]
     target: Option<String>,
     /// Abort the compilation after finishing the analysis
     #[clap(long, env)]
@@ -116,7 +116,7 @@ pub struct ParseableDumpArgs {
     /// more comprehensive explanation refer to the [notion page on
     /// dumping](https://www.notion.so/justus-adam/Dumping-Intermediate-Representations-4bd66ec11f8f4c459888a8d8cfb10e93).
     ///
-    /// Can also be supplied as a comma-separated list (no spaces) and be set with the `PARABLE_DUMP` variable.
+    /// Can also be supplied as a comma-separated list (no spaces) and be set with the `PARALEGAL_DUMP` variable.
     #[clap(long, value_enum)]
     dump: Vec<DumpArgs>,
 }

--- a/crates/paralegal-flow/tests/_contile_tests.rs (ignored)
+++ b/crates/paralegal-flow/tests/_contile_tests.rs (ignored)
@@ -9,7 +9,7 @@ use helpers::*;
 const CRATE_DIR: &str = "tests/contile-tests";
 
 lazy_static! {
-    static ref TEST_CRATE_ANALYZED: bool = *helpers::PARABLE_INSTALLED
+    static ref TEST_CRATE_ANALYZED: bool = *helpers::PARALEGAL_INSTALLED
         && with_current_directory(CRATE_DIR, || {
             run_paralegal-flow_with_graph_dump_and(["--drop-poll", "--drop-clone"])
         })


### PR DESCRIPTION
## What Changed?

Changes the `PARABEL` prefix to `PARALEGAL` in the env variables that the flow analyzer reads.

## Why Does It Need To?

Anther change that should have been part of #44 but wasn't

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [x] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [x] Documentation in Notion has been updated
- [x] Tests for new behaviors are provided
  - [x] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.