### PR TITLE
Add ctrl and data+ctrl flows_to matrices to the CtrlFlowsTo struct

### DIFF
--- a/crates/paralegal-flow/src/frg.rs
+++ b/crates/paralegal-flow/src/frg.rs
@@ -659,7 +659,7 @@ impl<'tcx> ForgeConverter<'tcx> {
                                 if a.refinement.on_return() {
                                     Some(
                                         self.description
-                                            .all_sources_with_ctrl()
+                                            .all_sources()
                                             .into_iter()
                                             .filter(|(_, s)| {
                                                 s.as_function_call()

--- a/crates/paralegal-policy/src/context.rs
+++ b/crates/paralegal-policy/src/context.rs
@@ -183,11 +183,29 @@ impl Context {
             .collect()
     }
 
-    /// Returns true if `src` has a data-flow to `sink` in the controller `ctrl_id`
+    /// Returns true if `src` has a data+ctrl-flow to `sink` in the controller `ctrl_id`
     pub fn flows_to(&self, ctrl_id: ControllerId, src: &DataSource, sink: &DataSink) -> bool {
         let ctrl_flows = &self.flows_to[&ctrl_id];
         ctrl_flows
             .data_flows_to
+            .row_set(&src.to_index(&ctrl_flows.sources))
+            .contains(sink)
+    }
+
+	/// Returns true if `src` has a data-flow to `sink` in the controller `ctrl_id`
+    pub fn data_flows_to(&self, ctrl_id: ControllerId, src: &DataSource, sink: &DataSink) -> bool {
+        let ctrl_flows = &self.flows_to[&ctrl_id];
+        ctrl_flows
+            .data_flows_to
+            .row_set(&src.to_index(&ctrl_flows.sources))
+            .contains(sink)
+    }
+
+	/// Returns true if `src` has a data-flow to `sink` in the controller `ctrl_id`
+    pub fn ctrl_flows_to(&self, ctrl_id: ControllerId, src: &DataSource, sink: &DataSink) -> bool {
+        let ctrl_flows = &self.flows_to[&ctrl_id];
+        ctrl_flows
+            .ctrl_flows_to
             .row_set(&src.to_index(&ctrl_flows.sources))
             .contains(sink)
     }

--- a/crates/paralegal-policy/src/context.rs
+++ b/crates/paralegal-policy/src/context.rs
@@ -179,7 +179,7 @@ impl Context {
     fn build_flows_to(desc: &ProgramDescription) -> FlowsTo {
         desc.controllers
             .iter()
-            .map(|(id, c)| (*id, CtrlFlowsTo::build(c)))
+            .map(|(id, c)| (*id, CtrlFlowsTo::build(c, &desc.annotations)))
             .collect()
     }
 
@@ -187,7 +187,7 @@ impl Context {
     pub fn flows_to(&self, ctrl_id: ControllerId, src: &DataSource, sink: &DataSink) -> bool {
         let ctrl_flows = &self.flows_to[&ctrl_id];
         ctrl_flows
-            .flows_to
+            .data_flows_to
             .row_set(&src.to_index(&ctrl_flows.sources))
             .contains(sink)
     }

--- a/crates/paralegal-policy/src/context.rs
+++ b/crates/paralegal-policy/src/context.rs
@@ -179,7 +179,7 @@ impl Context {
     fn build_flows_to(desc: &ProgramDescription) -> FlowsTo {
         desc.controllers
             .iter()
-            .map(|(id, c)| (*id, CtrlFlowsTo::build(c, &desc.annotations)))
+            .map(|(id, c)| (*id, CtrlFlowsTo::build(c)))
             .collect()
     }
 

--- a/crates/paralegal-policy/src/flows_to.rs
+++ b/crates/paralegal-policy/src/flows_to.rs
@@ -31,12 +31,12 @@ pub struct CtrlFlowsTo {
 
 impl CtrlFlowsTo {
     /// Constructs the transitive closure from a [`Ctrl`].
-    pub fn build(ctrl: &Ctrl, annotations: &AnnotationMap) -> Self {
+    pub fn build(ctrl: &Ctrl) -> Self {
         // Collect all sources and sinks into indexed domains.
 		let sources = Arc::new(IndexedDomain::from_iter(
 			ctrl.all_sources().iter().map(|&s| s.clone())));
         let sinks = Arc::new(IndexedDomain::from_iter(
-            ctrl.all_sinks(annotations).iter().map(|&s| s.clone()),
+            ctrl.all_sinks().iter().map(|&s| s.clone()),
         ));
 
         // Connect each function-argument sink to its corresponding function sources.

--- a/crates/paralegal-policy/src/flows_to.rs
+++ b/crates/paralegal-policy/src/flows_to.rs
@@ -132,7 +132,7 @@ impl fmt::Debug for CtrlFlowsTo {
 fn test_flows_to() {
     use paralegal_spdg::Identifier;
     let ctx = crate::test_utils::test_ctx();
-    let controller = ctx.find_by_name("controller_with_ctrl").unwrap();
+    let controller = ctx.find_by_name("controller_data_ctrl").unwrap();
     let src = DataSource::Argument(0);
     let get_sink = |name| {
         let name = Identifier::new_intern(name);
@@ -174,4 +174,26 @@ fn test_data_flows_to() {
     let sink2 = get_sink("sink2");
     assert!(ctx.data_flows_to(controller, &src, sink1));
     assert!(!ctx.data_flows_to(controller, &src, sink2));
+}
+
+#[test]
+fn test_ctrl_flows_to() {
+    use paralegal_spdg::Identifier;
+    let ctx = crate::test_utils::test_ctx();
+    let controller = ctx.find_by_name("controller_data_ctrl").unwrap();
+    let src = DataSource::Argument(0);
+    let get_sink = |name| {
+        let name = Identifier::new_intern(name);
+        ctx.desc().controllers[&controller]
+            .data_sinks()
+            .find(|sink| match sink {
+                DataSink::Argument { function, .. } => {
+                    ctx.desc().def_info[&function.function].name == name
+                }
+                _ => false,
+            })
+            .unwrap()
+    };
+    let sink1 = get_sink("sink1");
+    assert!(ctx.flows_to(controller, &src, sink1));
 }

--- a/crates/paralegal-policy/src/flows_to.rs
+++ b/crates/paralegal-policy/src/flows_to.rs
@@ -132,7 +132,7 @@ impl fmt::Debug for CtrlFlowsTo {
 fn test_flows_to() {
     use paralegal_spdg::Identifier;
     let ctx = crate::test_utils::test_ctx();
-    let controller = ctx.find_by_name("controller").unwrap();
+    let controller = ctx.find_by_name("controller_with_ctrl").unwrap();
     let src = DataSource::Argument(0);
     let get_sink = |name| {
         let name = Identifier::new_intern(name);
@@ -149,5 +149,29 @@ fn test_flows_to() {
     let sink1 = get_sink("sink1");
     let sink2 = get_sink("sink2");
     assert!(ctx.flows_to(controller, &src, sink1));
-    assert!(!ctx.flows_to(controller, &src, sink2));
+    assert!(ctx.flows_to(controller, &src, sink2));
+}
+
+#[test]
+fn test_data_flows_to() {
+    use paralegal_spdg::Identifier;
+    let ctx = crate::test_utils::test_ctx();
+    let controller = ctx.find_by_name("controller").unwrap();
+    let src = DataSource::Argument(0);
+    let get_sink = |name| {
+        let name = Identifier::new_intern(name);
+        ctx.desc().controllers[&controller]
+            .data_sinks()
+            .find(|sink| match sink {
+                DataSink::Argument { function, .. } => {
+                    ctx.desc().def_info[&function.function].name == name
+                }
+                _ => false,
+            })
+            .unwrap()
+    };
+    let sink1 = get_sink("sink1");
+    let sink2 = get_sink("sink2");
+    assert!(ctx.data_flows_to(controller, &src, sink1));
+    assert!(!ctx.data_flows_to(controller, &src, sink2));
 }

--- a/crates/paralegal-policy/tests/test-crate/src/lib.rs
+++ b/crates/paralegal-policy/tests/test-crate/src/lib.rs
@@ -4,16 +4,28 @@
 #[paralegal_flow::marker(input)]
 pub struct Foo;
 
-#[paralegal_flow::label{ sink, arguments = [0] }]
+#[paralegal_flow::marker{ sink, arguments = [0] }]
 fn sink1(_f: Foo) {}
 
-#[paralegal_flow::label{ sink, arguments = [0] }]
+#[paralegal_flow::marker{ sink, arguments = [0] }]
 fn sink2(_f: Foo) {}
+
+#[paralegal_flow::marker{ cond, arguments = [0] }]
+fn cond(_f: Foo) -> bool {
+	return true
+}
 
 #[paralegal_flow::analyze]
 fn controller(a: Foo, b: Foo) {
     sink1(a);
     sink2(b);
+}
+
+#[paralegal_flow::analyze]
+fn controller_with_ctrl(a: Foo, b: Foo) {
+	if cond(a) {
+		sink1(b);
+	}
 }
 
 #[paralegal_flow::marker(start, return)]

--- a/crates/paralegal-policy/tests/test-crate/src/lib.rs
+++ b/crates/paralegal-policy/tests/test-crate/src/lib.rs
@@ -22,8 +22,15 @@ fn controller(a: Foo, b: Foo) {
 }
 
 #[paralegal_flow::analyze]
-fn controller_with_ctrl(a: Foo, b: Foo) {
+fn controller_data_ctrl(a: Foo, b: Foo) {
 	if cond(a) {
+		sink1(b);
+	}
+}
+
+#[paralegal_flow::analyze]
+fn controller_ctrl(a: bool, b: Foo) {
+	if a {
 		sink1(b);
 	}
 }


### PR DESCRIPTION
## What Changed?

* Differentiated between `data_flows_to`, `ctrl_flows_to`, and `flows_to` IndexMatrices, which calculate transitive flows_to relations on the sources and sinks of a controller's `data_flow`, `ctrl_flow`, and both respectively. 
* Created new `all_sources` and `all_sinks` functions on the `Ctrl` struct. Because ctrl_flow is DataSource -> Callsite and not DataSource -> DataSink, for all Callsites we just make up a DataSink on the first argument of the function (which live in the new `ctrl_sinks` field in the `Ctrl` struct). This is required to capture flows to Callsites that do not have any DataSinks in the data_flow so that the `flows_to` IndexMatrix is correct. 

## Why Does It Need To?

Set up for new `flows_to` primitives for policies that want to talk about both data and control flow. 

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [x] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [x] Documentation in Notion has been updated
- [ ] Tests for new behaviors are provided - TODO - some failures
  - [ ] New test suites (if any) have been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.