### PR TITLE
New Context API that uses CtrlNodes

### DIFF
--- a/crates/paralegal-policy/src/context.rs
+++ b/crates/paralegal-policy/src/context.rs
@@ -151,7 +151,7 @@ impl<'a> Node<'a> {
 /// Interface for defining policies.
 ///
 /// Holds a PDG ([`Self::desc`]) and defines basic queries like
-/// [`Self::marked_sinks`] and combinators such as
+/// [`Self::all_nodes_for_ctrl`] and combinators such as
 /// [`Self::always_happens_before`]. These should be composed into more complex
 /// policies.
 ///

--- a/crates/paralegal-policy/src/context.rs
+++ b/crates/paralegal-policy/src/context.rs
@@ -583,14 +583,14 @@ fn test_context() {
     let controller = ctx.find_by_name("controller").unwrap();
 
     assert_eq!(
-        ctx.all_nodes_for_ctrl(&controller)
-            .filter(|n| ctx.has_marker(input, n))
+        ctx.all_nodes_for_ctrl(controller)
+            .filter(|n| ctx.has_marker(input, *n))
             .count(),
         0
     );
     assert_eq!(
-        ctx.all_nodes_for_ctrl(&controller)
-            .filter(|n| ctx.has_marker(sink, n))
+        ctx.all_nodes_for_ctrl(controller)
+            .filter(|n| ctx.has_marker(sink, *n))
             .count(),
         2
     );

--- a/crates/paralegal-policy/src/context.rs
+++ b/crates/paralegal-policy/src/context.rs
@@ -126,17 +126,17 @@ impl<'a> Node<'a> {
     pub fn as_call_site_or_data_sink(&self) -> Option<CallSiteOrDataSink> {
         match self {
             Node::CtrlArgument(_) => None,
-            Node::CallSite(&ref cs) => Some(cs.clone().into()),
-            Node::CallArgument(&ref ds) => Some(ds.clone().into()),
-            Node::Return(&ref ds) => Some(ds.clone().into()),
+            Node::CallSite(cs) => Some((*cs).clone().into()),
+            Node::CallArgument(ds) => Some((*ds).clone().into()),
+            Node::Return(ds) => Some((*ds).clone().into()),
         }
     }
 
     /// Transform a Node into it's corresponding owned DataSource - only works for CtrlArgs, CallSites, and CallArguments. Clones underlying data.
     pub fn as_data_source(&self) -> Option<DataSource> {
         match self {
-            Node::CtrlArgument(&ref ds) => Some(ds.clone()),
-            Node::CallSite(&ref cs) => Some(DataSource::FunctionCall(cs.clone())),
+            Node::CtrlArgument(ds) => Some((*ds).clone()),
+            Node::CallSite(cs) => Some(DataSource::FunctionCall((*cs).clone())),
             Node::CallArgument(ds) => match ds {
                 DataSink::Argument { function, .. } => {
                     Some(DataSource::FunctionCall(function.clone()))

--- a/crates/paralegal-policy/src/context.rs
+++ b/crates/paralegal-policy/src/context.rs
@@ -468,10 +468,8 @@ impl Context {
                     num_checkpointed += 1;
                 } else if is_terminal(sink_node) {
                     num_reached += 1;
-                } else {
-                    if seen.insert(sink_node) {
-                        queue.push(sink_node);
-                    }
+                } else if seen.insert(sink_node) {
+                    queue.push(sink_node);
                 }
             }
         }

--- a/crates/paralegal-policy/src/flows_to.rs
+++ b/crates/paralegal-policy/src/flows_to.rs
@@ -2,8 +2,6 @@ use paralegal_spdg::{
     CallSiteOrDataSink, CallSiteOrDataSinkIndex, Ctrl, DataSink, DataSource, DataSourceIndex,
 };
 
-use crate::CtrlNode;
-
 use indexical::{impls::BitvecArcIndexMatrix as IndexMatrix, IndexedDomain, ToIndex};
 
 use std::{fmt, sync::Arc};
@@ -159,7 +157,7 @@ fn test_data_flows_to() {
     use paralegal_spdg::Identifier;
     let ctx = crate::test_utils::test_ctx();
     let controller = ctx.find_by_name("controller").unwrap();
-    let src = CtrlNode {
+    let src = crate::CtrlNode {
         ctrl_id: &controller,
         node: (&DataSource::Argument(0)).into(),
     };
@@ -174,7 +172,7 @@ fn test_data_flows_to() {
                 _ => false,
             })
             .unwrap();
-        CtrlNode {
+        crate::CtrlNode {
             ctrl_id: &controller,
             node: node.into(),
         }
@@ -190,15 +188,15 @@ fn test_ctrl_flows_to() {
     use paralegal_spdg::Identifier;
     let ctx = crate::test_utils::test_ctx();
     let controller = ctx.find_by_name("controller_ctrl").unwrap();
-    let src_a = CtrlNode {
+    let src_a = crate::CtrlNode {
         ctrl_id: &controller,
         node: (&DataSource::Argument(0)).into(),
     };
-    let src_b = CtrlNode {
+    let src_b = crate::CtrlNode {
         ctrl_id: &controller,
         node: (&DataSource::Argument(1)).into(),
     };
-    let src_c = CtrlNode {
+    let src_c = crate::CtrlNode {
         ctrl_id: &controller,
         node: (&DataSource::Argument(2)).into(),
     };
@@ -208,7 +206,7 @@ fn test_ctrl_flows_to() {
             .call_sites()
             .find(|callsite| ctx.desc().def_info[&callsite.function].name == name)
             .unwrap();
-        CtrlNode {
+        crate::CtrlNode {
             ctrl_id: &controller,
             node: node.into(),
         }
@@ -227,11 +225,11 @@ fn test_flows_to() {
     use paralegal_spdg::Identifier;
     let ctx = crate::test_utils::test_ctx();
     let controller = ctx.find_by_name("controller_data_ctrl").unwrap();
-    let src_a = CtrlNode {
+    let src_a = crate::CtrlNode {
         ctrl_id: &controller,
         node: (&DataSource::Argument(0)).into(),
     };
-    let src_b = CtrlNode {
+    let src_b = crate::CtrlNode {
         ctrl_id: &controller,
         node: (&DataSource::Argument(1)).into(),
     };
@@ -246,7 +244,7 @@ fn test_flows_to() {
                 _ => false,
             })
             .unwrap();
-        CtrlNode {
+        crate::CtrlNode {
             ctrl_id: &controller,
             node: node.into(),
         }
@@ -257,7 +255,7 @@ fn test_flows_to() {
             .call_sites()
             .find(|callsite| ctx.desc().def_info[&callsite.function].name == name)
             .unwrap();
-        CtrlNode {
+        crate::CtrlNode {
             ctrl_id: &controller,
             node: node.into(),
         }

--- a/crates/paralegal-policy/src/flows_to.rs
+++ b/crates/paralegal-policy/src/flows_to.rs
@@ -158,7 +158,7 @@ fn test_data_flows_to() {
     let ctx = crate::test_utils::test_ctx();
     let controller = ctx.find_by_name("controller").unwrap();
     let src = crate::Node {
-        ctrl_id: &controller,
+        ctrl_id: controller,
         node: (&DataSource::Argument(0)).into(),
     };
     let get_sink_node = |name| {
@@ -173,14 +173,14 @@ fn test_data_flows_to() {
             })
             .unwrap();
         crate::Node {
-            ctrl_id: &controller,
+            ctrl_id: controller,
             node: node.into(),
         }
     };
     let sink1 = get_sink_node("sink1");
     let sink2 = get_sink_node("sink2");
-    assert!(ctx.flows_to(&src, &sink1, crate::EdgeType::Data));
-    assert!(!ctx.flows_to(&src, &sink2, crate::EdgeType::Data));
+    assert!(ctx.flows_to(src, sink1, crate::EdgeType::Data));
+    assert!(!ctx.flows_to(src, sink2, crate::EdgeType::Data));
 }
 
 #[test]
@@ -189,15 +189,15 @@ fn test_ctrl_flows_to() {
     let ctx = crate::test_utils::test_ctx();
     let controller = ctx.find_by_name("controller_ctrl").unwrap();
     let src_a = crate::Node {
-        ctrl_id: &controller,
+        ctrl_id: controller,
         node: (&DataSource::Argument(0)).into(),
     };
     let src_b = crate::Node {
-        ctrl_id: &controller,
+        ctrl_id: controller,
         node: (&DataSource::Argument(1)).into(),
     };
     let src_c = crate::Node {
-        ctrl_id: &controller,
+        ctrl_id: controller,
         node: (&DataSource::Argument(2)).into(),
     };
     let get_callsite_node = |name| {
@@ -207,17 +207,17 @@ fn test_ctrl_flows_to() {
             .find(|callsite| ctx.desc().def_info[&callsite.function].name == name)
             .unwrap();
         crate::Node {
-            ctrl_id: &controller,
+            ctrl_id: controller,
             node: node.into(),
         }
     };
     let cs1 = get_callsite_node("sink1");
     let cs2 = get_callsite_node("sink2");
-    assert!(ctx.flows_to(&src_a, &cs1, crate::EdgeType::Control));
-    assert!(ctx.flows_to(&src_c, &cs2, crate::EdgeType::Control));
-    assert!(ctx.flows_to(&src_a, &cs2, crate::EdgeType::Control));
-    assert!(!ctx.flows_to(&src_b, &cs1, crate::EdgeType::Control));
-    assert!(!ctx.flows_to(&src_b, &cs2, crate::EdgeType::Control));
+    assert!(ctx.flows_to(src_a, cs1, crate::EdgeType::Control));
+    assert!(ctx.flows_to(src_c, cs2, crate::EdgeType::Control));
+    assert!(ctx.flows_to(src_a, cs2, crate::EdgeType::Control));
+    assert!(!ctx.flows_to(src_b, cs1, crate::EdgeType::Control));
+    assert!(!ctx.flows_to(src_b, cs2, crate::EdgeType::Control));
 }
 
 #[test]
@@ -226,11 +226,11 @@ fn test_flows_to() {
     let ctx = crate::test_utils::test_ctx();
     let controller = ctx.find_by_name("controller_data_ctrl").unwrap();
     let src_a = crate::Node {
-        ctrl_id: &controller,
+        ctrl_id: controller,
         node: (&DataSource::Argument(0)).into(),
     };
     let src_b = crate::Node {
-        ctrl_id: &controller,
+        ctrl_id: controller,
         node: (&DataSource::Argument(1)).into(),
     };
     let get_sink_node = |name| {
@@ -245,7 +245,7 @@ fn test_flows_to() {
             })
             .unwrap();
         crate::Node {
-            ctrl_id: &controller,
+            ctrl_id: controller,
             node: node.into(),
         }
     };
@@ -256,16 +256,16 @@ fn test_flows_to() {
             .find(|callsite| ctx.desc().def_info[&callsite.function].name == name)
             .unwrap();
         crate::Node {
-            ctrl_id: &controller,
+            ctrl_id: controller,
             node: node.into(),
         }
     };
     let sink = get_sink_node("sink1");
     let cs = get_callsite_node("sink1");
     // a flows to the sink1 callsite (by ctrl flow)
-    assert!(ctx.flows_to(&src_a, &cs, crate::EdgeType::DataAndControl));
-    assert!(!ctx.flows_to(&src_a, &cs, crate::EdgeType::Data));
+    assert!(ctx.flows_to(src_a, cs, crate::EdgeType::DataAndControl));
+    assert!(!ctx.flows_to(src_a, cs, crate::EdgeType::Data));
     // b flows to the sink1 datasink (by data flow)
-    assert!(ctx.flows_to(&src_b, &sink, crate::EdgeType::DataAndControl));
-    assert!(ctx.flows_to(&src_b, &sink, crate::EdgeType::Data));
+    assert!(ctx.flows_to(src_b, sink, crate::EdgeType::DataAndControl));
+    assert!(ctx.flows_to(src_b, sink, crate::EdgeType::Data));
 }

--- a/crates/paralegal-policy/src/flows_to.rs
+++ b/crates/paralegal-policy/src/flows_to.rs
@@ -36,9 +36,7 @@ impl CtrlFlowsTo {
     /// Constructs the transitive closure from a [`Ctrl`].
     pub fn build(ctrl: &Ctrl) -> Self {
         // Collect all sources and sinks into indexed domains.
-        let sources = Arc::new(IndexedDomain::from_iter(
-            ctrl.all_sources().map(|s| s.clone()),
-        ));
+        let sources = Arc::new(IndexedDomain::from_iter(ctrl.all_sources().cloned()));
         let sinks = Arc::new(IndexedDomain::from_iter(ctrl.all_call_sites_or_sinks()));
 
         // Connect each function-argument sink to its corresponding function sources.

--- a/crates/paralegal-policy/src/flows_to.rs
+++ b/crates/paralegal-policy/src/flows_to.rs
@@ -157,7 +157,7 @@ fn test_data_flows_to() {
     use paralegal_spdg::Identifier;
     let ctx = crate::test_utils::test_ctx();
     let controller = ctx.find_by_name("controller").unwrap();
-    let src = crate::CtrlNode {
+    let src = crate::Node {
         ctrl_id: &controller,
         node: (&DataSource::Argument(0)).into(),
     };
@@ -172,7 +172,7 @@ fn test_data_flows_to() {
                 _ => false,
             })
             .unwrap();
-        crate::CtrlNode {
+        crate::Node {
             ctrl_id: &controller,
             node: node.into(),
         }
@@ -188,15 +188,15 @@ fn test_ctrl_flows_to() {
     use paralegal_spdg::Identifier;
     let ctx = crate::test_utils::test_ctx();
     let controller = ctx.find_by_name("controller_ctrl").unwrap();
-    let src_a = crate::CtrlNode {
+    let src_a = crate::Node {
         ctrl_id: &controller,
         node: (&DataSource::Argument(0)).into(),
     };
-    let src_b = crate::CtrlNode {
+    let src_b = crate::Node {
         ctrl_id: &controller,
         node: (&DataSource::Argument(1)).into(),
     };
-    let src_c = crate::CtrlNode {
+    let src_c = crate::Node {
         ctrl_id: &controller,
         node: (&DataSource::Argument(2)).into(),
     };
@@ -206,7 +206,7 @@ fn test_ctrl_flows_to() {
             .call_sites()
             .find(|callsite| ctx.desc().def_info[&callsite.function].name == name)
             .unwrap();
-        crate::CtrlNode {
+        crate::Node {
             ctrl_id: &controller,
             node: node.into(),
         }
@@ -225,11 +225,11 @@ fn test_flows_to() {
     use paralegal_spdg::Identifier;
     let ctx = crate::test_utils::test_ctx();
     let controller = ctx.find_by_name("controller_data_ctrl").unwrap();
-    let src_a = crate::CtrlNode {
+    let src_a = crate::Node {
         ctrl_id: &controller,
         node: (&DataSource::Argument(0)).into(),
     };
-    let src_b = crate::CtrlNode {
+    let src_b = crate::Node {
         ctrl_id: &controller,
         node: (&DataSource::Argument(1)).into(),
     };
@@ -244,7 +244,7 @@ fn test_flows_to() {
                 _ => false,
             })
             .unwrap();
-        crate::CtrlNode {
+        crate::Node {
             ctrl_id: &controller,
             node: node.into(),
         }
@@ -255,7 +255,7 @@ fn test_flows_to() {
             .call_sites()
             .find(|callsite| ctx.desc().def_info[&callsite.function].name == name)
             .unwrap();
-        crate::CtrlNode {
+        crate::Node {
             ctrl_id: &controller,
             node: node.into(),
         }

--- a/crates/paralegal-policy/src/flows_to.rs
+++ b/crates/paralegal-policy/src/flows_to.rs
@@ -159,7 +159,7 @@ fn test_data_flows_to() {
     let controller = ctx.find_by_name("controller").unwrap();
     let src = crate::Node {
         ctrl_id: controller,
-        node: (&DataSource::Argument(0)).into(),
+        typ: (&DataSource::Argument(0)).into(),
     };
     let get_sink_node = |name| {
         let name = Identifier::new_intern(name);
@@ -174,7 +174,7 @@ fn test_data_flows_to() {
             .unwrap();
         crate::Node {
             ctrl_id: controller,
-            node: node.into(),
+            typ: node.into(),
         }
     };
     let sink1 = get_sink_node("sink1");
@@ -190,15 +190,15 @@ fn test_ctrl_flows_to() {
     let controller = ctx.find_by_name("controller_ctrl").unwrap();
     let src_a = crate::Node {
         ctrl_id: controller,
-        node: (&DataSource::Argument(0)).into(),
+        typ: (&DataSource::Argument(0)).into(),
     };
     let src_b = crate::Node {
         ctrl_id: controller,
-        node: (&DataSource::Argument(1)).into(),
+        typ: (&DataSource::Argument(1)).into(),
     };
     let src_c = crate::Node {
         ctrl_id: controller,
-        node: (&DataSource::Argument(2)).into(),
+        typ: (&DataSource::Argument(2)).into(),
     };
     let get_callsite_node = |name| {
         let name = Identifier::new_intern(name);
@@ -208,7 +208,7 @@ fn test_ctrl_flows_to() {
             .unwrap();
         crate::Node {
             ctrl_id: controller,
-            node: node.into(),
+            typ: node.into(),
         }
     };
     let cs1 = get_callsite_node("sink1");
@@ -227,11 +227,11 @@ fn test_flows_to() {
     let controller = ctx.find_by_name("controller_data_ctrl").unwrap();
     let src_a = crate::Node {
         ctrl_id: controller,
-        node: (&DataSource::Argument(0)).into(),
+        typ: (&DataSource::Argument(0)).into(),
     };
     let src_b = crate::Node {
         ctrl_id: controller,
-        node: (&DataSource::Argument(1)).into(),
+        typ: (&DataSource::Argument(1)).into(),
     };
     let get_sink_node = |name| {
         let name = Identifier::new_intern(name);
@@ -246,7 +246,7 @@ fn test_flows_to() {
             .unwrap();
         crate::Node {
             ctrl_id: controller,
-            node: node.into(),
+            typ: node.into(),
         }
     };
     let get_callsite_node = |name| {
@@ -257,7 +257,7 @@ fn test_flows_to() {
             .unwrap();
         crate::Node {
             ctrl_id: controller,
-            node: node.into(),
+            typ: node.into(),
         }
     };
     let sink = get_sink_node("sink1");

--- a/crates/paralegal-spdg/src/lib.rs
+++ b/crates/paralegal-spdg/src/lib.rs
@@ -707,14 +707,13 @@ impl Ctrl {
     }
 
     /// Gather all [`DataSource`]s that are mentioned in this controller including data and control flow.
-    pub fn all_sources(&self) -> HashSet<&DataSource> {
+    pub fn all_sources(&self) -> impl Iterator<Item = &DataSource> + '_ {
         self.data_flow
             .0
             .keys()
             .chain(self.types.0.keys())
             .chain(self.ctrl_flow.0.keys())
             .dedup()
-            .collect()
     }
 
     /// Gather all [`DataSink`]s or [`CallSite`]s that are mentioned in this controller including data and control flow.

--- a/guide/deletion-policy/src/main.rs
+++ b/guide/deletion-policy/src/main.rs
@@ -25,18 +25,16 @@ fn deletion_policy(ctx: Arc<Context>) -> Result<()> {
         .marked_type(Marker::new_intern("user_data"))
         .collect::<Vec<_>>();
 
-    let found = ctx.all_controllers().any(|(deleter_id, deleter)| {
+    let found = ctx.all_controllers().any(|(deleter_id, _)| {
         let delete_sinks = ctx
-            .marked_sinks(deleter.data_sinks(), Marker::new_intern("deletes"))
-            .map(|s| s.clone().into())
+            .all_nodes_for_ctrl(&deleter_id)
+            .filter(|n| ctx.has_marker(Marker::new_intern("deletes"), n))
             .collect::<Vec<_>>();
-        let delete_sinks_borrowed = delete_sinks.iter().collect::<Vec<_>>();
         user_data_types.iter().all(|&t| {
-            let sources = ctx.srcs_with_type(deleter, t).collect::<Vec<_>>();
+            let sources = ctx.srcs_with_type(&deleter_id, t).collect::<Vec<_>>();
             ctx.any_flows(
-                Some(deleter_id),
-                &sources,
-                &delete_sinks_borrowed,
+                &sources.iter().collect::<Vec<_>>(),
+                &delete_sinks.iter().collect::<Vec<_>>(),
                 paralegal_policy::EdgeType::Data,
             )
             .is_some()

--- a/guide/deletion-policy/src/main.rs
+++ b/guide/deletion-policy/src/main.rs
@@ -27,17 +27,13 @@ fn deletion_policy(ctx: Arc<Context>) -> Result<()> {
 
     let found = ctx.all_controllers().any(|(deleter_id, _)| {
         let delete_sinks = ctx
-            .all_nodes_for_ctrl(&deleter_id)
-            .filter(|n| ctx.has_marker(Marker::new_intern("deletes"), n))
+            .all_nodes_for_ctrl(deleter_id)
+            .filter(|n| ctx.has_marker(Marker::new_intern("deletes"), *n))
             .collect::<Vec<_>>();
         user_data_types.iter().all(|&t| {
-            let sources = ctx.srcs_with_type(&deleter_id, t).collect::<Vec<_>>();
-            ctx.any_flows(
-                &sources.iter().collect::<Vec<_>>(),
-                &delete_sinks.iter().collect::<Vec<_>>(),
-                paralegal_policy::EdgeType::Data,
-            )
-            .is_some()
+            let sources = ctx.srcs_with_type(deleter_id, t).collect::<Vec<_>>();
+            ctx.any_flows(&sources, &delete_sinks, paralegal_policy::EdgeType::Data)
+                .is_some()
         })
     });
     assert_error!(ctx, found, "Could not find a controller deleting all types");

--- a/props/lemmy/src/main.rs
+++ b/props/lemmy/src/main.rs
@@ -4,11 +4,7 @@ use anyhow::{anyhow, Result};
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use paralegal_policy::{
-    assert_error,
-    paralegal_spdg::{CallSite, Ctrl, DataSink, DataSource, Identifier},
-    ControllerId, CtrlNode, Marker, PolicyContext,
-};
+use paralegal_policy::{assert_error, paralegal_spdg::Identifier, CtrlNode, Marker, PolicyContext};
 
 pub struct CommunityProp {
     cx: Arc<PolicyContext>,

--- a/props/plume/src/main.rs
+++ b/props/plume/src/main.rs
@@ -54,11 +54,11 @@ fn check(ctx: Arc<Context>) -> Result<()> {
         .into_iter()
         .find(|(deleter_id, _)| {
             let delete_sinks = ctx
-                .all_nodes_for_ctrl(&deleter_id)
+                .all_nodes_for_ctrl(deleter_id)
                 .filter(|n| ctx.has_marker(marker!(to_delete), n))
                 .collect::<Vec<_>>();
             user_data_types.iter().all(|&t| {
-                let sources = ctx.srcs_with_type(&deleter_id, t).collect::<Vec<_>>();
+                let sources = ctx.srcs_with_type(deleter_id, t).collect::<Vec<_>>();
                 ctx.any_flows(
                     &sources.iter().collect::<Vec<_>>(),
                     &delete_sinks.iter().collect::<Vec<_>>(),

--- a/props/plume/src/main.rs
+++ b/props/plume/src/main.rs
@@ -48,25 +48,17 @@ impl ContextExt for Context {
 fn check(ctx: Arc<Context>) -> Result<()> {
     let user_data_types = ctx.marked_type(marker!(user_data)).collect::<Vec<_>>();
 
-    let found = ctx
-        .all_controllers()
-        .collect::<Vec<_>>()
-        .into_iter()
-        .find(|(deleter_id, _)| {
-            let delete_sinks = ctx
-                .all_nodes_for_ctrl(deleter_id)
-                .filter(|n| ctx.has_marker(marker!(to_delete), n))
-                .collect::<Vec<_>>();
-            user_data_types.iter().all(|&t| {
-                let sources = ctx.srcs_with_type(deleter_id, t).collect::<Vec<_>>();
-                ctx.any_flows(
-                    &sources.iter().collect::<Vec<_>>(),
-                    &delete_sinks.iter().collect::<Vec<_>>(),
-                    paralegal_policy::EdgeType::Data,
-                )
+    let found = ctx.all_controllers().find(|(deleter_id, _)| {
+        let delete_sinks = ctx
+            .all_nodes_for_ctrl(*deleter_id)
+            .filter(|n| ctx.has_marker(marker!(to_delete), *n))
+            .collect::<Vec<_>>();
+        user_data_types.iter().all(|&t| {
+            let sources = ctx.srcs_with_type(*deleter_id, t).collect::<Vec<_>>();
+            ctx.any_flows(&sources, &delete_sinks, paralegal_policy::EdgeType::Data)
                 .is_some()
-            })
-        });
+        })
+    });
     if found.is_none() {
         ctx.error("Could not find a function deleting all types");
     }

--- a/props/websubmit/src/main.rs
+++ b/props/websubmit/src/main.rs
@@ -17,11 +17,11 @@ impl DeletionProp {
     fn flows_to_store(&self, t: DefId) -> bool {
         let stores = Marker::new_intern("stores");
 
-        for (c_id, c) in &self.cx.desc().controllers {
+        for (c_id, _) in &self.cx.desc().controllers {
             let t_srcs = self.cx.srcs_with_type(c_id, t);
             let store_cs = self
                 .cx
-                .all_nodes_for_ctrl(ctrl_id)
+                .all_nodes_for_ctrl(c_id)
                 .filter(|n| self.cx.has_marker(stores, n))
                 .collect::<Vec<_>>();
 
@@ -46,7 +46,7 @@ impl DeletionProp {
         let mut ots = self.cx.otypes(t);
         ots.push(t);
 
-        for (c_id, c) in &self.cx.desc().controllers {
+        for (c_id, _) in &self.cx.desc().controllers {
             for ot in &ots {
                 let t_srcs = self.cx.srcs_with_type(c_id, *ot).collect::<Vec<_>>();
                 let delete_cs = self
@@ -59,7 +59,7 @@ impl DeletionProp {
                     for &delete in &delete_cs {
                         if self
                             .cx
-                            .flows_to(&t_src, &delete, paralegal_policy::EdgeType::Data)
+                            .flows_to(t_src, &delete, paralegal_policy::EdgeType::Data)
                         {
                             return true;
                         }

--- a/props/websubmit/src/main.rs
+++ b/props/websubmit/src/main.rs
@@ -18,18 +18,18 @@ impl DeletionProp {
         let stores = Marker::new_intern("stores");
 
         for c_id in self.cx.desc().controllers.keys() {
-            let t_srcs = self.cx.srcs_with_type(c_id, t);
+            let t_srcs = self.cx.srcs_with_type(*c_id, t);
             let store_cs = self
                 .cx
-                .all_nodes_for_ctrl(c_id)
-                .filter(|n| self.cx.has_marker(stores, n))
+                .all_nodes_for_ctrl(*c_id)
+                .filter(|n| self.cx.has_marker(stores, *n))
                 .collect::<Vec<_>>();
 
             for t_src in t_srcs {
-                for &store in &store_cs {
+                for store in &store_cs {
                     if self
                         .cx
-                        .flows_to(&t_src, &store, paralegal_policy::EdgeType::Data)
+                        .flows_to(t_src, *store, paralegal_policy::EdgeType::Data)
                     {
                         return true;
                     }
@@ -48,18 +48,18 @@ impl DeletionProp {
 
         for c_id in self.cx.desc().controllers.keys() {
             for ot in &ots {
-                let t_srcs = self.cx.srcs_with_type(c_id, *ot).collect::<Vec<_>>();
+                let t_srcs = self.cx.srcs_with_type(*c_id, *ot);
                 let delete_cs = self
                     .cx
-                    .all_nodes_for_ctrl(c_id)
-                    .filter(|n| self.cx.has_marker(deletes, n))
+                    .all_nodes_for_ctrl(*c_id)
+                    .filter(|n| self.cx.has_marker(deletes, *n))
                     .collect::<Vec<_>>();
 
-                for t_src in &t_srcs {
-                    for &delete in &delete_cs {
+                for t_src in t_srcs {
+                    for delete in &delete_cs {
                         if self
                             .cx
-                            .flows_to(t_src, &delete, paralegal_policy::EdgeType::Data)
+                            .flows_to(t_src, *delete, paralegal_policy::EdgeType::Data)
                         {
                             return true;
                         }

--- a/props/websubmit/src/main.rs
+++ b/props/websubmit/src/main.rs
@@ -18,20 +18,19 @@ impl DeletionProp {
         let stores = Marker::new_intern("stores");
 
         for (c_id, c) in &self.cx.desc().controllers {
-            let t_srcs = self.cx.srcs_with_type(c, t);
+            let t_srcs = self.cx.srcs_with_type(c_id, t);
             let store_cs = self
                 .cx
-                .marked_sinks(c.data_sinks(), stores)
+                .all_nodes_for_ctrl(ctrl_id)
+                .filter(|n| self.cx.has_marker(stores, n))
                 .collect::<Vec<_>>();
 
             for t_src in t_srcs {
                 for &store in &store_cs {
-                    if self.cx.flows_to(
-                        Some(*c_id),
-                        t_src,
-                        &store.clone().into(),
-                        paralegal_policy::EdgeType::Data,
-                    ) {
+                    if self
+                        .cx
+                        .flows_to(&t_src, &store, paralegal_policy::EdgeType::Data)
+                    {
                         return true;
                     }
                 }
@@ -49,20 +48,19 @@ impl DeletionProp {
 
         for (c_id, c) in &self.cx.desc().controllers {
             for ot in &ots {
-                let t_srcs = self.cx.srcs_with_type(c, *ot).collect::<Vec<_>>();
+                let t_srcs = self.cx.srcs_with_type(c_id, *ot).collect::<Vec<_>>();
                 let delete_cs = self
                     .cx
-                    .marked_sinks(c.data_sinks(), deletes)
+                    .all_nodes_for_ctrl(c_id)
+                    .filter(|n| self.cx.has_marker(deletes, n))
                     .collect::<Vec<_>>();
 
                 for t_src in &t_srcs {
                     for &delete in &delete_cs {
-                        if self.cx.flows_to(
-                            Some(*c_id),
-                            t_src,
-                            &delete.clone().into(),
-                            paralegal_policy::EdgeType::Data,
-                        ) {
+                        if self
+                            .cx
+                            .flows_to(&t_src, &delete, paralegal_policy::EdgeType::Data)
+                        {
                             return true;
                         }
                     }

--- a/props/websubmit/src/main.rs
+++ b/props/websubmit/src/main.rs
@@ -17,7 +17,7 @@ impl DeletionProp {
     fn flows_to_store(&self, t: DefId) -> bool {
         let stores = Marker::new_intern("stores");
 
-        for (c_id, _) in &self.cx.desc().controllers {
+        for c_id in self.cx.desc().controllers.keys() {
             let t_srcs = self.cx.srcs_with_type(c_id, t);
             let store_cs = self
                 .cx
@@ -46,7 +46,7 @@ impl DeletionProp {
         let mut ots = self.cx.otypes(t);
         ots.push(t);
 
-        for (c_id, _) in &self.cx.desc().controllers {
+        for c_id in self.cx.desc().controllers.keys() {
             for ot in &ots {
                 let t_srcs = self.cx.srcs_with_type(c_id, *ot).collect::<Vec<_>>();
                 let delete_cs = self


### PR DESCRIPTION
## What Changed?

Created new `CtrlNode` struct that can represent any node in the SPDG (`CallSites`, `CallArguments`, `CtrlArguments`, and `Return`) coupled with the corresponding `ControllerId`. Updated all of `Context`'s APIs to use this new struct and all of the props/examples to use the new APIs. 

Some APIs like `has_marker` are not yet fully implemented. 

## Why Does It Need To?

More intuitive way to reason about the SPDG just based on nodes so properties do not need to differentiate between the different types of nodes if it is not necessary, which in most cases it isn't. Also makes the policies more flexible, because now we can say "any node that is marked x flows into any node that is marked y" rather than needing to know the specific type of node it is. 

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [x] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [x] Documentation in Notion has been updated
- [x] Tests for new behaviors are provided 
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.