### PR TITLE
Fully implement the has_marker function

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,7 @@ jobs:
         cargo test -p paralegal-flow --test new_alias_analysis_tests
         cargo test -p paralegal-flow --test async_tests
         cargo test -p paralegal-flow --test inline_elision_tests
-        cargo test -p paralegal-policy --lib -- flows_to
+        cargo test -p paralegal-policy --lib
     - name: Build Test Policies
       run: |
         cd props

--- a/crates/paralegal-flow/src/test_utils.rs
+++ b/crates/paralegal-flow/src/test_utils.rs
@@ -135,7 +135,12 @@ where
     S: AsRef<std::ffi::OsStr>,
 {
     paralegal_flow_command(dir)
-        .args(["--abort-after-analysis", "--dump", "serialized-flow-graph"])
+        .args([
+            "--abort-after-analysis",
+            "--dump",
+            "serialized-flow-graph",
+            "--eager-local-markers",
+        ])
         .args(extra)
         .status()
         .unwrap()

--- a/crates/paralegal-flow/src/test_utils.rs
+++ b/crates/paralegal-flow/src/test_utils.rs
@@ -135,12 +135,7 @@ where
     S: AsRef<std::ffi::OsStr>,
 {
     paralegal_flow_command(dir)
-        .args([
-            "--abort-after-analysis",
-            "--dump",
-            "serialized-flow-graph",
-            "--eager-local-markers",
-        ])
+        .args(["--abort-after-analysis", "--dump", "serialized-flow-graph"])
         .args(extra)
         .status()
         .unwrap()

--- a/crates/paralegal-policy/src/context.rs
+++ b/crates/paralegal-policy/src/context.rs
@@ -645,7 +645,6 @@ fn test_context() {
         2
     );
     // The 3rd argument and the return of the controller.
-    // TODO: Below fails. Why?
     assert_eq!(
         ctx.all_nodes_for_ctrl(controller)
             .filter(|n| ctx.has_marker(Marker::new_intern("ctrl"), *n))

--- a/crates/paralegal-policy/src/context.rs
+++ b/crates/paralegal-policy/src/context.rs
@@ -320,18 +320,24 @@ impl Context {
             .flat_map(|v| v.iter())
     }
 
+    /// Get the type(s) of a Node.
+    pub fn get_node_types(&self, node: &Node) -> Option<&HashSet<DefId>> {
+        match node.typ.as_data_source() {
+            None => None,
+            Some(src) => self.desc.controllers[&node.ctrl_id].types.get(&src),
+        }
+    }
+
     /// Returns whether the given Node has the marker applied to it directly or via its type.
     pub fn has_marker(&self, marker: Marker, node: Node) -> bool {
-        if let Some(src) = node.typ.as_data_source() {
-            if let Some(typ) = &self.desc.controllers[&node.ctrl_id].types.get(&src) {
-                if typ.iter().any(|t| {
-                    self.marker_to_ids
-                        .get(&marker)
-                        .map(|markers| markers.iter().any(|(id, _)| id == t))
-                        .unwrap_or(false)
-                }) {
-                    return true;
-                }
+        if let Some(types) = self.get_node_types(&node) {
+            if types.iter().any(|t| {
+                self.marker_to_ids
+                    .get(&marker)
+                    .map(|markers| markers.iter().any(|(id, _)| id == t))
+                    .unwrap_or(false)
+            }) {
+                return true;
             }
         }
 

--- a/crates/paralegal-policy/src/context.rs
+++ b/crates/paralegal-policy/src/context.rs
@@ -644,12 +644,13 @@ fn test_context() {
             .count(),
         2
     );
+    // The 3rd argument and the return of the controller.
     // TODO: Below fails. Why?
     assert_eq!(
         ctx.all_nodes_for_ctrl(controller)
             .filter(|n| ctx.has_marker(Marker::new_intern("ctrl"), *n))
             .count(),
-        1
+        2
     );
 }
 

--- a/crates/paralegal-policy/tests/test-crate/src/lib.rs
+++ b/crates/paralegal-policy/tests/test-crate/src/lib.rs
@@ -7,6 +7,11 @@ pub struct Foo;
 #[paralegal_flow::marker{ sink, arguments = [0] }]
 fn sink1(_f: Foo) {}
 
+#[paralegal_flow::marker{ src, return }]
+fn identity(f: Foo) -> Foo {
+    f
+}
+
 #[paralegal_flow::marker{ sink, arguments = [0] }]
 fn sink2(_f: Foo) {}
 
@@ -16,9 +21,10 @@ fn cond(_f: Foo) -> bool {
 }
 
 #[paralegal_flow::analyze]
+#[paralegal_flow::marker{ ctrl, return }]
 fn controller(a: Foo, b: Foo) {
     sink1(a);
-    sink2(b);
+    sink2(identity(b));
 }
 
 #[paralegal_flow::analyze]

--- a/crates/paralegal-policy/tests/test-crate/src/lib.rs
+++ b/crates/paralegal-policy/tests/test-crate/src/lib.rs
@@ -22,9 +22,11 @@ fn cond(_f: Foo) -> bool {
 
 #[paralegal_flow::analyze]
 #[paralegal_flow::marker{ ctrl, return }]
-fn controller(a: Foo, b: Foo) {
+#[paralegal_flow::marker{ ctrl, arguments = [2] }]
+fn controller(a: Foo, b: Foo, c: bool) -> bool {
     sink1(a);
     sink2(identity(b));
+    c
 }
 
 #[paralegal_flow::analyze]


### PR DESCRIPTION
## What Changed?

`has_marker` fn implemented to: 
* Discover markers on the return of the controller
* Discover markers on nodes via the type of the node

## Why Does It Need To?

Self explanatory

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [x] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [x] Documentation in Notion has been updated
- [x] Tests for new behaviors are provided
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.