### PR TITLE
Change always_happens_before to not take in ctrl id and work over multiple controllers

### DIFF
--- a/crates/paralegal-policy/src/context.rs
+++ b/crates/paralegal-policy/src/context.rs
@@ -506,6 +506,7 @@ impl Context {
         };
 
         while let Some(current) = queue.pop() {
+            // Check the datasource.
             if check_node(Node {
                 ctrl_id: current.1,
                 typ: (&current.0).into(),
@@ -513,6 +514,7 @@ impl Context {
                 continue;
             }
 
+            // Check all sinks the source flows to.
             for sink in current.2.get(&current.0).into_iter().flatten() {
                 if check_node(Node {
                     ctrl_id: current.1,
@@ -520,6 +522,7 @@ impl Context {
                 }) {
                     continue;
                 } else if let DataSink::Argument { function, .. } = sink {
+                    // If the sink is an argument, it can be converted to a datasource and added to the queue.
                     if seen.insert(sink) {
                         queue.push((function.clone().into(), current.1, current.2));
                     }

--- a/crates/paralegal-policy/src/context.rs
+++ b/crates/paralegal-policy/src/context.rs
@@ -420,7 +420,7 @@ impl Context {
     /// Enforce that on every data flow path from the `starting_points` to `is_terminal` a
     /// node satisfying `is_checkpoint` is passed.
     ///
-    /// Fails if `ctrl` is not found.
+    /// Fails if `ctrl_id` on a provided starting point is not found.
     ///
     /// The return value contains some statistics information about the
     /// traversal. The property holds if [`AlwaysHappensBefore::holds`] is true.

--- a/crates/paralegal-spdg/src/lib.rs
+++ b/crates/paralegal-spdg/src/lib.rs
@@ -569,6 +569,12 @@ impl DataSource {
     }
 }
 
+impl From<CallSite> for DataSource {
+    fn from(cs: CallSite) -> Self {
+        DataSource::FunctionCall(cs)
+    }
+}
+
 /// A representation of something that can receive data from the flow.
 ///
 /// [`Self::as_argument`] is provided for convenience of matching.


### PR DESCRIPTION
## What Changed?

See title. Instead, use the ctrl_id attached to the nodes.

## Why Does It Need To?

Nodes carry ctrl_id with them, so this API makes more sense, and it also more in line with the rest of the Context APIs. 

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [x] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [x] Documentation in Notion has been updated
- [x] Tests for new behaviors are provided
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.