### PR TITLE
Remove Laziness for Markers

### DIFF
--- a/crates/paralegal-flow/src/ana/mod.rs
+++ b/crates/paralegal-flow/src/ana/mod.rs
@@ -1,6 +1,8 @@
 //! Data-and control flow analyzer and inliner.
 //!
-//!
+//! Analysis starts with the construction of [`SPDGGenerator`] from a
+//! [`CollectingVisitor`](crate::discover::CollectingVisitor) and then calling
+//! [`analyze`](SPDGGenerator::analyze).
 
 use std::borrow::Cow;
 
@@ -24,6 +26,9 @@ pub mod non_transitive_aliases;
 pub type SerializableInlinedGraph<L> =
     petgraph::graphmap::GraphMap<regal::SimpleLocation<L>, inline::Edge, petgraph::Directed>;
 
+/// Read-only database of information the analysis needs.
+///
+/// [`Self::analyze`] serves as the main entrypoint to SPDG generation.
 pub struct SPDGGenerator<'tcx> {
     pub marker_ctx: MarkerCtx<'tcx>,
     pub opts: &'static crate::Args,

--- a/crates/paralegal-flow/src/ana/mod.rs
+++ b/crates/paralegal-flow/src/ana/mod.rs
@@ -14,7 +14,7 @@ use mir::Location;
 
 use anyhow::Result;
 
-use super::discover::{CallSiteAnnotations, CollectingVisitor, FnToAnalyze};
+use super::discover::{CallSiteAnnotations, FnToAnalyze};
 
 pub mod algebra;
 pub mod df;

--- a/crates/paralegal-flow/src/args.rs
+++ b/crates/paralegal-flow/src/args.rs
@@ -371,11 +371,6 @@ impl ModelCtrl {
 /// Arguments which control marker assignment and discovery
 #[derive(serde::Serialize, serde::Deserialize, clap::Args)]
 pub struct MarkerControl {
-    /// Eagerly load markers for local items. This guarantees that all markers
-    /// on local items are emitted in the model, even if those items are never
-    /// used in the flow.
-    #[clap(long, env = "PARALEGAL_EAGER_LOCAL_MARKERS")]
-    eager_local_markers: bool,
     /// Don't mark the outputs of local functions if they are of a marked type.
     ///
     /// Be aware that disabling this can cause unsoundness as inline
@@ -386,10 +381,6 @@ pub struct MarkerControl {
 }
 
 impl MarkerControl {
-    pub fn lazy_local_markers(&self) -> bool {
-        !self.eager_local_markers
-    }
-
     pub fn local_function_type_marking(&self) -> bool {
         !self.no_local_function_type_marking
     }

--- a/crates/paralegal-flow/src/discover.rs
+++ b/crates/paralegal-flow/src/discover.rs
@@ -4,7 +4,6 @@
 //! annotations.
 use crate::{
     ana::SPDGGenerator, consts, desc::*, marker_db::MarkerDatabase, rust::*, utils::*, HashMap,
-    MarkerCtx,
 };
 
 use hir::{
@@ -79,7 +78,7 @@ impl<'tcx> CollectingVisitor<'tcx> {
         let tcx = self.tcx;
         tcx.hir().visit_all_item_likes_in_crate(&mut self);
         //println!("{:?}\n{:?}\n{:?}", self.marked_sinks, self.marked_sources, self.functions_to_analyze);
-        let mut targets = std::mem::take(&mut self.functions_to_analyze);
+        let targets = std::mem::take(&mut self.functions_to_analyze);
         self.into_generator().analyze(&targets)
     }
 

--- a/crates/paralegal-flow/src/lib.rs
+++ b/crates/paralegal-flow/src/lib.rs
@@ -169,8 +169,7 @@ impl rustc_driver::Callbacks for Callbacks {
             .global_ctxt()
             .unwrap()
             .enter(|tcx| {
-                let marker_ctx = MarkerCtx::new(tcx, self.opts);
-                let desc = discover::CollectingVisitor::new(tcx, self.opts, marker_ctx).run()?;
+                let desc = discover::CollectingVisitor::new(tcx, self.opts).run()?;
                 if self.opts.dbg().dump_serialized_flow_graph() {
                     serde_json::to_writer(
                         &mut std::fs::OpenOptions::new()

--- a/crates/paralegal-flow/src/marker_db.rs
+++ b/crates/paralegal-flow/src/marker_db.rs
@@ -1,5 +1,13 @@
 //! Central repository for information about markers (and annotations).
 //!
+//! The database ([`MarkerDatabase`]) is initialized with
+//! ([`init`](`MarkerDatabase::init`)) and populated with local markers by
+//! [`CollectingVisitor`](crate::discover::CollectingVisitor) by calls to
+//! ([`retrieve_local_annotations_for`](MarkerDatabase::retrieve_local_annotations_for)).
+//! Then it's transformed into a read-only [`MarkerCtx`] via [`From::from`]. The
+//! [`MarkerCtx`] is a cheap pointer to the database and responsible for
+//! answering queries about markers as the main analysis runs.
+//!
 //! All interactions happen through the central database object: [`MarkerCtx`].
 
 use crate::{

--- a/crates/paralegal-flow/src/marker_db.rs
+++ b/crates/paralegal-flow/src/marker_db.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     DefId, HashMap, LocalDefId, TyCtxt,
 };
-use rustc_utils::cache::{Cache, CopyCache};
+use rustc_utils::cache::CopyCache;
 
 use std::rc::Rc;
 
@@ -112,7 +112,7 @@ impl<'tcx> MarkerCtx<'tcx> {
         self.db()
             .local_annotations
             .iter()
-            .filter_map(|(k, v)| Some((*k, (v.as_slice()))))
+            .map(|(k, v)| (*k, (v.as_slice())))
             .collect()
     }
 

--- a/guide/deletion-policy/src/main.rs
+++ b/guide/deletion-policy/src/main.rs
@@ -10,10 +10,8 @@ fn dummy_policy(ctx: Arc<Context>) -> Result<()> {
 fn main() -> Result<()> {
     let dir = "../file-db-example/";
     let mut cmd = paralegal_policy::SPDGGenCommand::global();
-    cmd.get_command().args([
-        "--external-annotations",
-        "external-annotations.toml",
-    ]);
+    cmd.get_command()
+        .args(["--external-annotations", "external-annotations.toml"]);
     cmd.run(dir)?.with_context(dummy_policy)?;
     println!("Policy successful");
     Ok(())

--- a/guide/deletion-policy/src/main.rs
+++ b/guide/deletion-policy/src/main.rs
@@ -13,7 +13,6 @@ fn main() -> Result<()> {
     cmd.get_command().args([
         "--external-annotations",
         "external-annotations.toml",
-        "--eager-local-markers",
     ]);
     cmd.run(dir)?.with_context(dummy_policy)?;
     println!("Policy successful");

--- a/props/plume/src/main.rs
+++ b/props/plume/src/main.rs
@@ -95,7 +95,6 @@ fn main() -> Result<()> {
         "--inline-elision",
         "--target",
         "plume_models",
-        "--eager-local-markers",
         "--",
         "--no-default-features",
         "--features",


### PR DESCRIPTION
## What Changed?

Eagerly visit all IDs in the program under analysis and register potential markers.
Rips out all the infrastructure that was used to do it lazily.

Refactors the `CollectingVisitor` into two structs, the visitor and then an `SPDGGenerator` that runs the actual analysis. This separates the concerns out better. The former stores (among other things) a mutable `MarkerDatabase` that it fills with the markers for local functions and types and it collects a vector of analysis targets. 
Once the visit is done it is converted into the `SPDGGenerator` which stores the read-only `MarkerCtx`.

## Why Does It Need To?

Lazy markers were confusing. Markers on controllers were never registered. Also could cause surprising vacuity if markers were never encountered because e.g. their call sites happened in a closure.

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [x] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [x] Documentation in Notion has been updated
  - [x] Remove from list of arguments
  - [x] Remove from step-by-step guide
- [x] Tests for new behaviors are provided
  - [x] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.