### PR TITLE
Update the paralegal-policy test runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,9 @@ jobs:
           target/
         key: ${{ runner.os }}-rust-deps-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}
     - name: Build
-      run: cargo install --locked --path crates/paralegal-flow --verbose
+      run: |
+        cargo install --locked --path crates/paralegal-flow --verbose
+        cargo build --verbose
     - name: Run tests
       run: |
         cargo test -p paralegal-flow --test non_transitive_graph_tests

--- a/crates/paralegal-flow/src/test_utils.rs
+++ b/crates/paralegal-flow/src/test_utils.rs
@@ -86,7 +86,6 @@ pub fn paralegal_flow_command(dir: impl AsRef<Path>) -> std::process::Command {
     let mut cmd = std::process::Command::new(cargo_paralegal_flow_path);
     cmd.arg("paralegal-flow")
         .env("PATH", new_path)
-        .env("RUST_BACKTRACE", "1")
         .current_dir(dir);
     eprintln!("Command is {cmd:?}");
     cmd

--- a/crates/paralegal-flow/src/test_utils.rs
+++ b/crates/paralegal-flow/src/test_utils.rs
@@ -67,7 +67,7 @@ pub fn run_paralegal_flow_with_graph_dump(dir: impl AsRef<Path>) -> bool {
 /// `PATH`.
 pub fn paralegal_flow_command(dir: impl AsRef<Path>) -> std::process::Command {
     let path = std::env::var("PATH").unwrap_or_else(|_| Default::default());
-    let cargo_paralegal_flow_path = Path::new("../../target/debug/cargo-paralegal-flow")
+    let cargo_paralegal_flow_path = Path::new("../../target/release/cargo-paralegal-flow")
         .canonicalize()
         .unwrap();
     let mut new_path = std::ffi::OsString::with_capacity(
@@ -86,6 +86,7 @@ pub fn paralegal_flow_command(dir: impl AsRef<Path>) -> std::process::Command {
     let mut cmd = std::process::Command::new(cargo_paralegal_flow_path);
     cmd.arg("paralegal-flow")
         .env("PATH", new_path)
+        .env("RUST_BACKTRACE", "1")
         .current_dir(dir);
     eprintln!("Command is {cmd:?}");
     cmd


### PR DESCRIPTION
## What Changed?

Use the release version of `paralegal-flow` in the test runner and set `RUST_BACKTRACE=1`.  

## Why Does It Need To?

The test runner sometimes uses in the incorrect version of `paralegal-flow`. `RUST_BACKTRACE=1` will also allows us to see the output in the CI.

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [ ] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [ ] Documentation in Notion has been updated
- [ ] Tests for new behaviors are provided
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.