### PR TITLE
Minor improvements to policy framework

### DIFF
--- a/crates/paralegal-policy/src/lib.rs
+++ b/crates/paralegal-policy/src/lib.rs
@@ -98,8 +98,27 @@ impl SPDGGenCommand {
     }
 
     /// Mutably borrow the command to perform further customization.
+    ///
+    /// This gives you raw access to the underlying command. Be aware that if
+    /// you pass `--` with [`Command::arg`] or [`Command:args`] then methods
+    /// such as [`Self::external_annotations`] and
+    /// [`Self::abort_after_analysis`] not longer work properly after this call.
     pub fn get_command(&mut self) -> &mut Command {
         &mut self.0
+    }
+
+    /// Pass the provided file as `--external-annotations` to the command.
+    pub fn external_annotations(&mut self, file: impl AsRef<Path>) -> &mut Self {
+        self.0
+            .args(["--external-annotations".as_ref(), file.as_ref().as_os_str()]);
+        self
+    }
+
+    /// Abort compilation once the analysis artifacts have been created. Also
+    /// sets the expectation for the compilation to succeed to `false`.
+    pub fn abort_after_analysis(&mut self) -> &mut Self {
+        self.0.arg("--abort-after-analysis");
+        self
     }
 
     /// Consume the created command and execute it in the specified directory.

--- a/crates/paralegal-policy/src/lib.rs
+++ b/crates/paralegal-policy/src/lib.rs
@@ -100,7 +100,7 @@ impl SPDGGenCommand {
     /// Mutably borrow the command to perform further customization.
     ///
     /// This gives you raw access to the underlying command. Be aware that if
-    /// you pass `--` with [`Command::arg`] or [`Command:args`] then methods
+    /// you pass `--` with [`Command::arg`] or [`Command::args`] then methods
     /// such as [`Self::external_annotations`] and
     /// [`Self::abort_after_analysis`] not longer work properly after this call.
     pub fn get_command(&mut self) -> &mut Command {


### PR DESCRIPTION
## What Changed?

- Adds an iterator over `ControllerContext`s to `Context`
- Adds the commonly used `abort_after_analysis` and `external_annotations` methods to the spdg-gen command builder

## Why Does It Need To?

Controller contexts provide additional information when emitting errors and warnings but are annoying to construct or easy to forget.

The command line options are some of the most used and this provides easier access.

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [x] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [ ] Documentation in Notion has been updated
- [ ] Tests for new behaviors are provided
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.