### PR TITLE
Use instances in marker reachability.

### DIFF
--- a/crates/paralegal-flow/src/ana/inline/judge.rs
+++ b/crates/paralegal-flow/src/ana/inline/judge.rs
@@ -1,4 +1,4 @@
-use crate::{mir::Place, utils::FnResolution, AnalysisCtrl, DefId, MarkerCtx, TyCtxt};
+use crate::{mir::Place, utils::FnResolution, AnalysisCtrl, MarkerCtx, TyCtxt};
 
 /// The interpretation of marker placement as it pertains to inlining and inline
 /// elision.

--- a/crates/paralegal-flow/src/ana/inline/judge.rs
+++ b/crates/paralegal-flow/src/ana/inline/judge.rs
@@ -40,7 +40,7 @@ impl<'tcx> InlineJudge<'tcx> {
     ) -> bool {
         self.analysis_control.avoid_inlining()
             && !self.function_has_markers(function)
-            && !self.marker_is_reachable(function.def_id())
+            && !self.marker_is_reachable(function)
             && !self.probably_performs_side_effects(function, args, place_has_dependencies)
     }
 
@@ -79,7 +79,7 @@ impl<'tcx> InlineJudge<'tcx> {
     }
 
     /// Is a marker reachable from this item?
-    fn marker_is_reachable(&self, def_id: DefId) -> bool {
-        self.marker_ctx.marker_is_reachable(def_id)
+    fn marker_is_reachable(&self, res: FnResolution<'tcx>) -> bool {
+        self.marker_ctx.marker_is_reachable(res)
     }
 }

--- a/crates/paralegal-flow/src/ana/inline/mod.rs
+++ b/crates/paralegal-flow/src/ana/inline/mod.rs
@@ -704,7 +704,7 @@ impl<'tcx> Inliner<'tcx> {
                     {
                         debug!("Inlining {function:?}");
                         return Some((id, *location, InlineAction::SimpleInline(local_id)));
-                    } else if self.marker_carrying.marker_ctx().has_transitive_reachable_markers(def_id) {
+                    } else if self.marker_carrying.marker_ctx().has_transitive_reachable_markers(*function) {
                         self.tcx.sess.struct_span_warn(
                             self.tcx.def_span(def_id),
                             "This function is not being inlined, but a marker is reachable from its inside.",

--- a/guide/file-db-example/Cargo.lock
+++ b/guide/file-db-example/Cargo.lock
@@ -3,5 +3,47 @@
 version = 3
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "file-db-example"
 version = "0.1.0"
+dependencies = [
+ "paralegal",
+]
+
+[[package]]
+name = "paralegal"
+version = "0.1.0"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"


### PR DESCRIPTION
## What Changed?

Computing marker reachability now uses monomorphized instances that properly propagate generic arguments. 

## Why Does It Need To?

This reduces the unsoundness issues in this method. Before the generics were basically ignored.

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [x] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [ ] Documentation in Notion has been updated
- [ ] Tests for new behaviors are provided
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.