### PR TITLE
Add test normalization to prevent hard errors in function resolution

### DIFF
--- a/crates/paralegal-flow/src/utils/mod.rs
+++ b/crates/paralegal-flow/src/utils/mod.rs
@@ -432,7 +432,7 @@ impl<'tcx> AsFnAndArgs<'tcx> for mir::Terminator<'tcx> {
                 FnResolution::Partial(*defid)
             }
             Ok(_) => ty::Instance::resolve(tcx, ty::ParamEnv::reveal_all(), *defid, gargs)
-            .map_err(|_| AsFnAndArgsErr::InstanceResolutionErr)?
+                .map_err(|_| AsFnAndArgsErr::InstanceResolutionErr)?
                 .map_or(FnResolution::Partial(*defid), FnResolution::Final),
         };
         Ok((

--- a/crates/paralegal-flow/src/utils/mod.rs
+++ b/crates/paralegal-flow/src/utils/mod.rs
@@ -377,22 +377,6 @@ pub trait AsFnAndArgs<'tcx> {
     >;
 }
 
-impl<'tcx> AsFnAndArgs<'tcx> for mir::Terminator<'tcx> {
-    fn as_instance_and_args(
-        &self,
-        tcx: TyCtxt<'tcx>,
-    ) -> Result<
-        (
-            FnResolution<'tcx>,
-            SimplifiedArguments<'tcx>,
-            mir::Place<'tcx>,
-        ),
-        AsFnAndArgsErr<'tcx>,
-    > {
-        self.kind.as_instance_and_args(tcx)
-    }
-}
-
 #[derive(Debug, Error)]
 pub enum AsFnAndArgsErr<'tcx> {
     #[error("not a constant")]
@@ -407,7 +391,7 @@ pub enum AsFnAndArgsErr<'tcx> {
     InstanceResolutionErr,
 }
 
-impl<'tcx> AsFnAndArgs<'tcx> for mir::TerminatorKind<'tcx> {
+impl<'tcx> AsFnAndArgs<'tcx> for mir::Terminator<'tcx> {
     fn as_instance_and_args(
         &self,
         tcx: TyCtxt<'tcx>,
@@ -424,7 +408,7 @@ impl<'tcx> AsFnAndArgs<'tcx> for mir::TerminatorKind<'tcx> {
             args,
             destination,
             ..
-        } = self
+        } = &self.kind
         else {
             return Err(AsFnAndArgsErr::NotAFunctionCall);
         };
@@ -436,15 +420,35 @@ impl<'tcx> AsFnAndArgs<'tcx> for mir::TerminatorKind<'tcx> {
         let (ty::FnDef(defid, gargs) | ty::Closure(defid, gargs)) = ty.kind() else {
             return Err(AsFnAndArgsErr::NotFunctionType(ty.kind().clone()));
         };
-        let instance = ty::Instance::resolve(tcx, ty::ParamEnv::reveal_all(), *defid, gargs)
+        let instance = match test_instance_resolve(tcx, gargs) {
+            Err(e) => {
+                tcx.sess.span_warn(
+                    self.source_info.span,
+                    format!(
+                        "Could not resolve instance for this call due to {e:?}, \
+                        using partial resolution."
+                    ),
+                );
+                FnResolution::Partial(*defid)
+            }
+            Ok(_) => ty::Instance::resolve(tcx, ty::ParamEnv::reveal_all(), *defid, gargs)
             .map_err(|_| AsFnAndArgsErr::InstanceResolutionErr)?
-            .map_or(FnResolution::Partial(*defid), FnResolution::Final);
+                .map_or(FnResolution::Partial(*defid), FnResolution::Final),
+        };
         Ok((
             instance,
             args.iter().map(|a| a.place()).collect(),
             *destination,
         ))
     }
+}
+
+fn test_instance_resolve<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    args: &'tcx ty::List<ty::GenericArg<'tcx>>,
+) -> Result<(), ty::normalize_erasing_regions::NormalizationError<'tcx>> {
+    tcx.try_normalize_erasing_regions(ty::ParamEnv::reveal_all(), args)
+        .map(|_| ())
 }
 
 /// A struct that can be used to apply a `FnMut` to every `Place` in a MIR

--- a/guide/file-db-example/Cargo.lock
+++ b/guide/file-db-example/Cargo.lock
@@ -3,5 +3,47 @@
 version = 3
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "file-db-example"
 version = "0.1.0"
+dependencies = [
+ "paralegal",
+]
+
+[[package]]
+name = "paralegal"
+version = "0.1.0"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"


### PR DESCRIPTION
## What Changed?

Add a test normalization for generic arguments when resolving call instances.

## Why Does It Need To?

Instance resolution can fail with a hard error if the generic arguments can't be resolved. We don't want that to be a hard error since it can arise from legitimate situations during our analysis. So we try the resolution separately before and catch it, reporting a graceful warning and carrying on.

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [x] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [ ] Documentation in Notion has been updated
- [ ] Tests for new behaviors are provided
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.