### PR TITLE
Fix up Websubmit props so that they pass/fail like Forge

### DIFF
--- a/crates/paralegal-policy/src/context.rs
+++ b/crates/paralegal-policy/src/context.rs
@@ -661,30 +661,7 @@ impl Context {
         let mut num_reached = 0;
         let mut num_checkpointed = 0;
 
-        let mut queue = starting_points
-            .filter_map(|n| match n.typ.as_data_source() {
-                Some(ds) => Some((
-                    ds,
-                    n.ctrl_id,
-                    &self.desc().controllers.get(&n.ctrl_id).unwrap().data_flow.0,
-                )),
-                None => {
-                    assert_warning!(
-                        *self,
-                        false,
-                        format!(
-                            "found starting point {:?} that cannot be converted to a datasource",
-                            n
-                        )
-                    );
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-
-        let started_with = queue.len();
-
-        // Return whether node is checkpoint or terminal and increment those respective counters
+		// Return whether node is checkpoint or terminal and increment those respective counters
         let mut check_node = |node: Node| -> bool {
             if is_checkpoint(node) {
                 num_checkpointed += 1;
@@ -695,6 +672,33 @@ impl Context {
             }
             false
         };
+
+        let starts = starting_points.collect::<Vec<_>>();
+		let started_with = starts.len();
+
+        let mut queue = starts.iter().filter_map(|n| {
+			if check_node(*n) {
+				return None;
+			}
+			match n.typ.as_data_source() {
+				Some(ds) => Some((
+					ds,
+					n.ctrl_id,
+					&self.desc().controllers.get(&n.ctrl_id).unwrap().data_flow.0,
+				)),
+				None => {
+					assert_warning!(
+						*self,
+						false,
+						format!(
+							"found starting point {:?} that cannot be converted to a datasource",
+							n
+						)
+					);
+					None
+				}
+			}
+		}).collect::<Vec<_>>();
 
         while let Some(current) = queue.pop() {
             // Check the datasource.

--- a/crates/paralegal-policy/src/context.rs
+++ b/crates/paralegal-policy/src/context.rs
@@ -661,7 +661,7 @@ impl Context {
         let mut num_reached = 0;
         let mut num_checkpointed = 0;
 
-		// Return whether node is checkpoint or terminal and increment those respective counters
+        // Return whether node is checkpoint or terminal and increment those respective counters
         let mut check_node = |node: Node| -> bool {
             if is_checkpoint(node) {
                 num_checkpointed += 1;
@@ -674,31 +674,34 @@ impl Context {
         };
 
         let starts = starting_points.collect::<Vec<_>>();
-		let started_with = starts.len();
+        let started_with = starts.len();
 
-        let mut queue = starts.iter().filter_map(|n| {
-			if check_node(*n) {
-				return None;
-			}
-			match n.typ.as_data_source() {
-				Some(ds) => Some((
-					ds,
-					n.ctrl_id,
-					&self.desc().controllers.get(&n.ctrl_id).unwrap().data_flow.0,
-				)),
-				None => {
-					assert_warning!(
-						*self,
-						false,
-						format!(
+        let mut queue = starts
+            .iter()
+            .filter_map(|n| {
+                if check_node(*n) {
+                    return None;
+                }
+                match n.typ.as_data_source() {
+                    Some(ds) => Some((
+                        ds,
+                        n.ctrl_id,
+                        &self.desc().controllers.get(&n.ctrl_id).unwrap().data_flow.0,
+                    )),
+                    None => {
+                        assert_warning!(
+                            *self,
+                            false,
+                            format!(
 							"found starting point {:?} that cannot be converted to a datasource",
 							n
 						)
-					);
-					None
-				}
-			}
-		}).collect::<Vec<_>>();
+                        );
+                        None
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
 
         while let Some(current) = queue.pop() {
             // Check the datasource.

--- a/crates/paralegal-policy/src/context.rs
+++ b/crates/paralegal-policy/src/context.rs
@@ -693,9 +693,9 @@ impl Context {
                             *self,
                             false,
                             format!(
-							"found starting point {:?} that cannot be converted to a datasource",
-							n
-						)
+                            "found starting point {:?} that cannot be converted to a datasource",
+                            n
+                        )
                         );
                         None
                     }

--- a/props/websubmit/Cargo.toml
+++ b/props/websubmit/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 paralegal-policy = { path = "../../crates/paralegal-policy" }
 anyhow = "1"
+clap = { version = "3", features = ["derive"] }

--- a/props/websubmit/src/main.rs
+++ b/props/websubmit/src/main.rs
@@ -74,7 +74,7 @@ impl DeletionProp {
             )
         }
 
-        return Ok(found_deleter);
+        Ok(found_deleter)
     }
 }
 
@@ -126,9 +126,9 @@ impl ScopedStorageProp {
                                     *scope,
                                     store_callsite,
                                     paralegal_policy::EdgeType::Data,
-                                ) && 
+                                ) &&
 								self.cx.influencers(
-									*scope, 
+									*scope,
 									paralegal_policy::EdgeType::Data
 								).any(|i| self.cx.has_marker(marker!(auth_witness), i))
                             });
@@ -159,7 +159,7 @@ impl ScopedStorageProp {
                 return Ok(controller_valid);
             }
         }
-        return Ok(true);
+        Ok(true)
     }
 }
 
@@ -303,25 +303,22 @@ fn main() -> Result<()> {
     };
 
     let mut command = paralegal_policy::SPDGGenCommand::global();
-	command.get_command().args([
-		"--model-version",
-		"v2",
-		"--inline-elision",
-		"--skip-sigs",
-		"--abort-after-analysis",
-		"--external-annotations",
-		format!("{}baseline-external-annotations.toml", ws_dir).as_str(),
-	]);
+    command.get_command().args([
+        "--model-version",
+        "v2",
+        "--inline-elision",
+        "--skip-sigs",
+        "--abort-after-analysis",
+        "--external-annotations",
+        format!("{}baseline-external-annotations.toml", ws_dir).as_str(),
+    ]);
 
-    match edit_name {
-        Some(edit) => {
-			if edit.as_str() != "none" {
-				command.get_command().args(["--", "--features", &edit]);
-			}
+    if let Some(edit) = edit_name {
+        if edit.as_str() != "none" {
+            command.get_command().args(["--", "--features", &edit]);
         }
-        None => (),
     }
     command.run(ws_dir)?.with_context(prop)?;
 
-    return Ok(());
+    Ok(())
 }

--- a/props/websubmit/src/main.rs
+++ b/props/websubmit/src/main.rs
@@ -22,7 +22,7 @@ impl DeletionProp {
         DeletionProp { cx }
     }
 
-    pub fn check(self) {
+    pub fn check(self) -> Result<bool> {
         // All types marked "sensitive"
         let types_to_check = self
             .cx
@@ -73,13 +73,14 @@ impl DeletionProp {
                 format!("Type: {}", self.cx.describe_def(ty))
             )
         }
+
+        return Ok(found_deleter);
     }
 }
 
-fn run_del_policy(ctx: Arc<Context>) -> Result<()> {
+pub fn run_del_policy(ctx: Arc<Context>) -> Result<bool> {
     ctx.named_policy(Identifier::new_intern("Deletion"), |ctx| {
-        DeletionProp::new(ctx).check();
-        Ok(())
+        DeletionProp::new(ctx).check()
     })
 }
 
@@ -94,7 +95,7 @@ impl ScopedStorageProp {
         ScopedStorageProp { cx }
     }
 
-    pub fn check(self) {
+    pub fn check(self) -> Result<bool> {
         for c_id in self.cx.desc().controllers.keys() {
             let scopes = self
                 .cx
@@ -125,7 +126,11 @@ impl ScopedStorageProp {
                                     *scope,
                                     store_callsite,
                                     paralegal_policy::EdgeType::Data,
-                                )
+                                ) && 
+								self.cx.influencers(
+									*scope, 
+									paralegal_policy::EdgeType::Data
+								).any(|i| self.cx.has_marker(marker!(auth_witness), i))
                             });
                             assert_error!(
                                 self.cx,
@@ -149,14 +154,18 @@ impl ScopedStorageProp {
                     self.cx.describe_def(*c_id)
                 ),
             );
+
+            if !controller_valid {
+                return Ok(controller_valid);
+            }
         }
+        return Ok(true);
     }
 }
 
-fn run_sc_policy(ctx: Arc<Context>) -> Result<()> {
+pub fn run_sc_policy(ctx: Arc<Context>) -> Result<bool> {
     ctx.named_policy(Identifier::new_intern("Scoped Storage"), |ctx| {
-        ScopedStorageProp::new(ctx).check();
-        Ok(())
+        ScopedStorageProp::new(ctx).check()
     })
 }
 
@@ -170,12 +179,12 @@ impl AuthDisclosureProp {
         AuthDisclosureProp { cx }
     }
 
-    pub fn check(self) -> Result<()> {
+    pub fn check(self) -> Result<bool> {
         for c_id in self.cx.desc().controllers.keys() {
             // All srcs that have no influencers
             let roots = self
                 .cx
-                .roots(*c_id, paralegal_policy::EdgeType::DataAndControl)
+                .roots(*c_id, paralegal_policy::EdgeType::Data)
                 .collect::<Vec<_>>();
 
             let safe_scopes = self
@@ -257,14 +266,18 @@ impl AuthDisclosureProp {
                         )
                     );
                     safe_before_scope.report(self.cx.clone());
+
+                    if !safe_before_scope.holds() {
+                        return Ok(false);
+                    }
                 }
             }
         }
-        Ok(())
+        Ok(true)
     }
 }
 
-fn run_dis_policy(ctx: Arc<Context>) -> Result<()> {
+pub fn run_dis_policy(ctx: Arc<Context>) -> Result<bool> {
     ctx.named_policy(Identifier::new_intern("Authorized Disclosure"), |ctx| {
         AuthDisclosureProp::new(ctx).check()
     })
@@ -273,8 +286,9 @@ fn run_dis_policy(ctx: Arc<Context>) -> Result<()> {
 fn main() -> Result<()> {
     let ws_dir = std::env::args()
         .nth(1)
-        .ok_or_else(|| anyhow!("expected format: cargo run <path> [policy]"))?;
-    let prop_name = std::env::args().nth(2);
+        .ok_or_else(|| anyhow!("expected format: cargo run <path> [edit-<property>-<articulation point>-<short edit type> | none] [policy]"))?;
+    let edit_name = std::env::args().nth(2);
+    let prop_name = std::env::args().nth(3);
 
     let prop = match prop_name {
         Some(s) => match s.as_str() {
@@ -288,7 +302,26 @@ fn main() -> Result<()> {
         },
     };
 
-    paralegal_policy::SPDGGenCommand::global()
-        .run(ws_dir)?
-        .with_context(prop)
+    let mut command = paralegal_policy::SPDGGenCommand::global();
+	command.get_command().args([
+		"--model-version",
+		"v2",
+		"--inline-elision",
+		"--skip-sigs",
+		"--abort-after-analysis",
+		"--external-annotations",
+		format!("{}baseline-external-annotations.toml", ws_dir).as_str(),
+	]);
+
+    match edit_name {
+        Some(edit) => {
+			if edit.as_str() != "none" {
+				command.get_command().args(["--", "--features", &edit]);
+			}
+        }
+        None => (),
+    }
+    command.run(ws_dir)?.with_context(prop)?;
+
+    return Ok(());
 }


### PR DESCRIPTION
## What Changed?

There were some small bugs with the Websubmit props that are fixed here, and now they pass/fail exactly like the baseline Forge properties for the edits.
* `always_happens_before` checks `is_checkpoint` and `is_terminal` before converting the starting points to srcs. 
* Scoped Storage requires `auth_witness` to flow into the `scope` (oops!!!)
* Authorized Disclosure roots are data roots, not data and control flow roots. 

Adds flags to the command that is run to take in external annotations among other flags that are used in the eval-driver. 

Also adds infrastructure to run particular edits of Websubmit and makes the properties return a `Result<bool>` to prepare for usage in the eval-driver. 

## Why Does It Need To?

Bug fixing

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [x] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [ ] Documentation in Notion has been updated
- [ ] Tests for new behaviors are provided
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.