### PR TITLE
Add graph location output path argument

### DIFF
--- a/crates/paralegal-flow/src/args.rs
+++ b/crates/paralegal-flow/src/args.rs
@@ -75,7 +75,7 @@ pub struct Args {
     /// Where to write the resulting forge code to (defaults to `analysis_result.frg`)
     result_path: std::path::PathBuf,
     /// Where to write the resulting GraphLocation (defaults to `flow-graph.json`)
-    pub graph_loc_path: std::path::PathBuf,
+    pub(crate) graph_loc_path: std::path::PathBuf,
     /// Emit warnings instead of aborting the analysis on sanity checks
     relaxed: bool,
 

--- a/crates/paralegal-flow/src/args.rs
+++ b/crates/paralegal-flow/src/args.rs
@@ -24,6 +24,7 @@ impl TryFrom<ClapArgs> for Args {
             debug,
             debug_target,
             result_path,
+            graph_loc_path,
             relaxed,
             target,
             abort_after_analysis,
@@ -53,6 +54,7 @@ impl TryFrom<ClapArgs> for Args {
             verbose,
             log_level_config,
             result_path,
+            graph_loc_path,
             relaxed,
             target,
             abort_after_analysis,
@@ -72,6 +74,8 @@ pub struct Args {
     log_level_config: LogLevelConfig,
     /// Where to write the resulting forge code to (defaults to `analysis_result.frg`)
     result_path: std::path::PathBuf,
+    /// Where to write the resulting GraphLocation (defaults to `flow-graph.json`)
+    pub graph_loc_path: std::path::PathBuf,
     /// Emit warnings instead of aborting the analysis on sanity checks
     relaxed: bool,
 
@@ -112,6 +116,9 @@ pub struct ClapArgs {
     /// Where to write the resulting forge code to (defaults to `analysis_result.frg`)
     #[clap(long, default_value = "analysis_result.frg")]
     result_path: std::path::PathBuf,
+    /// Where to write the resulting GraphLocation (defaults to `flow-graph.json`)
+    #[clap(long, default_value = "flow-graph.json")]
+    graph_loc_path: std::path::PathBuf,
     /// Emit warnings instead of aborting the analysis on sanity checks
     #[clap(long, env = "PARALEGAL_RELAXED")]
     relaxed: bool,

--- a/crates/paralegal-flow/src/lib.rs
+++ b/crates/paralegal-flow/src/lib.rs
@@ -178,7 +178,7 @@ impl rustc_driver::Callbacks for Callbacks {
                             .truncate(true)
                             .create(true)
                             .write(true)
-                            .open(consts::FLOW_GRAPH_OUT_NAME)
+                            .open(self.opts.graph_loc_path.clone())
                             .unwrap(),
                         &desc,
                     )


### PR DESCRIPTION
## What Changed?

Add new argument to `paralegal-flow` to dictate where to write the graph location json file. 

## Why Does It Need To?

Used for the eval driver for Websubmit (and probably future eval drivers too)

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [x] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [ ] Documentation in Notion has been updated
- [ ] Tests for new behaviors are provided
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.