### PR TITLE
Add has_ctrl_influence primitive to Context

### DIFF
--- a/crates/paralegal-policy/src/context.rs
+++ b/crates/paralegal-policy/src/context.rs
@@ -300,7 +300,7 @@ impl Context {
     ///
     /// Nodes do not flow to themselves. CallArgument nodes do flow to their respective CallSites.
     ///
-    /// If you use flows_to with [`EdgeType::Control`], you might want to consider using has_ctrl_influence.
+    /// If you use flows_to with [`EdgeType::Control`], you might want to consider using [`Context::has_ctrl_influence`], which additionally considers intermediate nodes which the src node has data flow to and has ctrl influence on the sink.
     pub fn flows_to(&self, src: Node, sink: Node, edge_type: EdgeType) -> bool {
         if src.ctrl_id != sink.ctrl_id {
             return false;
@@ -347,7 +347,9 @@ impl Context {
         }
     }
 
-    /// Returns whether there is direct control flow influence from influencer to sink, or is there is some data flow from influencer to something that has ctrl flow to sink.
+    /// Returns whether there is direct control flow influence from influencer to sink, or there is some node which is data-flow influenced by `influencer` and has direct control flow influence on `target`. Or as expressed in code:
+    ///
+    /// `some n where self.flows_to(influencer, n, EdgeType::Data) && self.flows_to(n, target, Edgetype::Control)`.
     pub fn has_ctrl_influence(&self, influencer: Node, target: Node) -> bool {
         let Some(tcs) = target.associated_call_site() else {
 				return false;

--- a/crates/paralegal-policy/src/context.rs
+++ b/crates/paralegal-policy/src/context.rs
@@ -300,7 +300,7 @@ impl Context {
     ///
     /// Nodes do not flow to themselves. CallArgument nodes do flow to their respective CallSites.
     ///
-    /// If you use flows_to with [`EdgeType::Control`], you might want to consider using [`Context::has_ctrl_influence`].
+    /// If you use flows_to with [`EdgeType::Control`], you might want to consider using has_ctrl_influence.
     pub fn flows_to(&self, src: Node, sink: Node, edge_type: EdgeType) -> bool {
         if src.ctrl_id != sink.ctrl_id {
             return false;
@@ -348,8 +348,7 @@ impl Context {
     }
 
     /// Returns whether there is direct control flow influence from influencer to sink, or is there is some data flow from influencer to something that has ctrl flow to sink.
-    #[allow(dead_code)]
-    fn has_ctrl_influence(&self, influencer: Node, target: Node) -> bool {
+    pub fn has_ctrl_influence(&self, influencer: Node, target: Node) -> bool {
         let Some(tcs) = target.associated_call_site() else {
 				return false;
 			};

--- a/crates/paralegal-policy/src/flows_to.rs
+++ b/crates/paralegal-policy/src/flows_to.rs
@@ -210,31 +210,14 @@ impl fmt::Debug for CtrlFlowsTo {
 
 #[test]
 fn test_data_flows_to() {
-    use paralegal_spdg::Identifier;
     let ctx = crate::test_utils::test_ctx();
     let controller = ctx.find_by_name("controller").unwrap();
     let src = crate::Node {
         ctrl_id: controller,
         typ: (&DataSource::Argument(0)).into(),
     };
-    let get_sink_node = |name| {
-        let name = Identifier::new_intern(name);
-        let node = ctx.desc().controllers[&controller]
-            .data_sinks()
-            .find(|sink| match sink {
-                DataSink::Argument { function, .. } => {
-                    ctx.desc().def_info[&function.function].name == name
-                }
-                _ => false,
-            })
-            .unwrap();
-        crate::Node {
-            ctrl_id: controller,
-            typ: node.into(),
-        }
-    };
-    let sink1 = get_sink_node("sink1");
-    let sink2 = get_sink_node("sink2");
+    let sink1 = crate::test_utils::get_sink_node(&ctx, controller, "sink1").unwrap();
+    let sink2 = crate::test_utils::get_sink_node(&ctx, controller, "sink2").unwrap();
     assert!(ctx.flows_to(src, sink1, crate::EdgeType::Data));
     assert!(!ctx.flows_to(src, sink2, crate::EdgeType::Data));
 }
@@ -255,8 +238,8 @@ fn test_ctrl_flows_to() {
         ctrl_id: controller,
         typ: (&DataSource::Argument(2)).into(),
     };
-    let cs1 = crate::test_utils::get_callsite_node(&ctx, controller, "sink1");
-    let cs2 = crate::test_utils::get_callsite_node(&ctx, controller, "sink2");
+    let cs1 = crate::test_utils::get_callsite_node(&ctx, controller, "sink1").unwrap();
+    let cs2 = crate::test_utils::get_callsite_node(&ctx, controller, "sink2").unwrap();
     assert!(ctx.flows_to(src_a, cs1, crate::EdgeType::Control));
     assert!(ctx.flows_to(src_c, cs2, crate::EdgeType::Control));
     assert!(ctx.flows_to(src_a, cs2, crate::EdgeType::Control));
@@ -276,8 +259,8 @@ fn test_flows_to() {
         ctrl_id: controller,
         typ: (&DataSource::Argument(1)).into(),
     };
-    let sink = crate::test_utils::get_sink_node(&ctx, controller, "sink1");
-    let cs = crate::test_utils::get_callsite_node(&ctx, controller, "sink1");
+    let sink = crate::test_utils::get_sink_node(&ctx, controller, "sink1").unwrap();
+    let cs = crate::test_utils::get_callsite_node(&ctx, controller, "sink1").unwrap();
     // a flows to the sink1 callsite (by ctrl flow)
     assert!(ctx.flows_to(src_a, cs, crate::EdgeType::DataAndControl));
     assert!(!ctx.flows_to(src_a, cs, crate::EdgeType::Data));
@@ -290,8 +273,8 @@ fn test_flows_to() {
 fn test_args_flow_to_cs() {
     let ctx = crate::test_utils::test_ctx();
     let controller = ctx.find_by_name("controller_data_ctrl").unwrap();
-    let sink = crate::test_utils::get_sink_node(&ctx, controller, "sink1");
-    let cs = crate::test_utils::get_callsite_node(&ctx, controller, "sink1");
+    let sink = crate::test_utils::get_sink_node(&ctx, controller, "sink1").unwrap();
+    let cs = crate::test_utils::get_callsite_node(&ctx, controller, "sink1").unwrap();
 
     assert!(ctx.flows_to(sink, cs, crate::EdgeType::Data));
     assert!(ctx.flows_to(sink, cs, crate::EdgeType::DataAndControl));

--- a/crates/paralegal-policy/src/lib.rs
+++ b/crates/paralegal-policy/src/lib.rs
@@ -175,7 +175,7 @@ impl GraphLocation {
     /// Prefer using [`Self::with_context`] which takes care of emitting any
     /// diagnostic messages after the property is done.
     pub fn build_context(&self) -> Result<Context> {
-        simple_logger::init_with_env().unwrap();
+        let _ = simple_logger::init_with_env();
 
         let desc = {
             let mut f = File::open(&self.0)?;

--- a/crates/paralegal-policy/src/test_utils.rs
+++ b/crates/paralegal-policy/src/test_utils.rs
@@ -19,23 +19,34 @@ pub fn test_ctx() -> Arc<Context> {
         .clone()
 }
 
+pub fn get_callsite_or_datasink_node<'a>(
+    ctx: &'a Context,
+    controller: ControllerId,
+    name: &'a str,
+) -> Option<Node<'a>> {
+    Some(get_callsite_node(ctx, controller, name).unwrap_or(get_sink_node(ctx, controller, name)?))
+}
+
 pub fn get_callsite_node<'a>(
     ctx: &'a Context,
     controller: ControllerId,
     name: &'a str,
-) -> Node<'a> {
+) -> Option<Node<'a>> {
     let name = Identifier::new_intern(name);
     let node = ctx.desc().controllers[&controller]
         .call_sites()
-        .find(|callsite| ctx.desc().def_info[&callsite.function].name == name)
-        .unwrap();
-    crate::Node {
+        .find(|callsite| ctx.desc().def_info[&callsite.function].name == name)?;
+    Some(crate::Node {
         ctrl_id: controller,
         typ: node.into(),
-    }
+    })
 }
 
-pub fn get_sink_node<'a>(ctx: &'a Context, controller: ControllerId, name: &'a str) -> Node<'a> {
+pub fn get_sink_node<'a>(
+    ctx: &'a Context,
+    controller: ControllerId,
+    name: &'a str,
+) -> Option<Node<'a>> {
     let name = Identifier::new_intern(name);
     let node = ctx.desc().controllers[&controller]
         .data_sinks()
@@ -44,10 +55,9 @@ pub fn get_sink_node<'a>(ctx: &'a Context, controller: ControllerId, name: &'a s
                 ctx.desc().def_info[&function.function].name == name
             }
             _ => false,
-        })
-        .unwrap();
-    crate::Node {
+        })?;
+    Some(crate::Node {
         ctrl_id: controller,
         typ: node.into(),
-    }
+    })
 }

--- a/crates/paralegal-policy/tests/test-crate/src/lib.rs
+++ b/crates/paralegal-policy/tests/test-crate/src/lib.rs
@@ -71,3 +71,17 @@ fn happens_before_fail() -> u32 {
     let val = create();
     id(val) + val
 }
+
+#[paralegal::marker(check, return)]
+fn validate_foo(a: Foo) -> bool {
+    return true;
+}
+
+#[paralegal::analyze]
+fn ctrl_influence(a: Foo, b: Foo) {
+    let a_prime = identity(a);
+    let b_prime = id(b);
+    if validate_foo(a_prime) {
+        sink1(b_prime);
+    }
+}


### PR DESCRIPTION
## What Changed?

Add a new primitive that checks whether a src has data then ctrl flow influence on a sink.

## Why Does It Need To?

Common pattern when we talk about control flow influence.

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [x] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [ ] Documentation in Notion has been updated
- [x] Tests for new behaviors are provided
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.