### PR TITLE
Make `NodeType`s own their info

### DIFF
--- a/crates/paralegal-flow/src/ana/mod.rs
+++ b/crates/paralegal-flow/src/ana/mod.rs
@@ -195,7 +195,7 @@ impl<'tcx> SPDGGenerator<'tcx> {
                 .collect();
             if !interesting_output_types.is_empty() {
                 flows.types.0.insert(
-                    DataSource::FunctionCall(call_site.clone()),
+                    DataSource::FunctionCall(call_site),
                     interesting_output_types,
                 );
             }
@@ -204,7 +204,7 @@ impl<'tcx> SPDGGenerator<'tcx> {
             for dep in deps.ctrl_deps.iter() {
                 flows.add_ctrl_flow(
                     Cow::Owned(data_source_from_global_location(*dep, tcx, check_realness)),
-                    call_site.clone(),
+                    call_site,
                 )
             }
 
@@ -224,7 +224,7 @@ impl<'tcx> SPDGGenerator<'tcx> {
                     DataSink::Return
                 } else {
                     DataSink::Argument {
-                        function: call_site.clone(),
+                        function: call_site,
                         arg_slot,
                     }
                 };
@@ -232,7 +232,7 @@ impl<'tcx> SPDGGenerator<'tcx> {
                     debug!("    to {dep}");
                     flows.add_data_flow(
                         Cow::Owned(data_source_from_global_location(*dep, tcx, check_realness)),
-                        to.clone(),
+                        to,
                     );
                 }
             }

--- a/crates/paralegal-flow/src/lib.rs
+++ b/crates/paralegal-flow/src/lib.rs
@@ -200,7 +200,7 @@ impl rustc_driver::Callbacks for Callbacks {
                 let info_path = compiler.build_output_filenames(compiler.session(), &[])
                     .with_extension("info.json");
                 let info = AdditionalInfo {
-                    call_sites: converter.desc().all_call_sites().into_iter().map(|cs| (call_site_to_string(tcx, cs), cs.clone())).collect()
+                    call_sites: converter.desc().all_call_sites().into_iter().map(|cs| (call_site_to_string(tcx, cs), *cs)).collect()
                 };
                 serde_json::to_writer(outfile_pls(info_path)?, &info)?;
 

--- a/crates/paralegal-flow/src/test_utils.rs
+++ b/crates/paralegal-flow/src/test_utils.rs
@@ -773,7 +773,7 @@ impl<'g> CallSiteRef<'g> {
                 .ctrl
                 .data_flow
                 .0
-                .get(&crate::desc::DataSource::FunctionCall(src.clone()))
+                .get(&crate::desc::DataSource::FunctionCall(src))
                 .iter()
                 .flat_map(|i| i.iter())
                 .map(Either::Left)
@@ -791,7 +791,7 @@ impl<'g> CallSiteRef<'g> {
         };
 
         let mut seen = HashSet::new();
-        let mut queue: Vec<_> = next_hop(self.call_site.clone());
+        let mut queue: Vec<_> = next_hop(*self.call_site);
         while let Some(n) = queue.pop() {
             if match n {
                 Either::Left(l) => sink == l,
@@ -805,10 +805,10 @@ impl<'g> CallSiteRef<'g> {
                 match n {
                     Either::Left(l) => {
                         if let Some((fun, _)) = l.as_argument() {
-                            queue.extend(next_hop(fun.clone()))
+                            queue.extend(next_hop(*fun))
                         }
                     }
-                    Either::Right(r) => queue.extend(next_hop(r.clone())),
+                    Either::Right(r) => queue.extend(next_hop(*r)),
                 };
             }
         }

--- a/crates/paralegal-policy/src/flows_to.rs
+++ b/crates/paralegal-policy/src/flows_to.rs
@@ -82,14 +82,14 @@ impl CtrlFlowsTo {
         // Collect all sources and sinks into indexed domains.
         let sources = Arc::new(IndexedDomain::from_iter(ctrl.all_sources().cloned().chain(
             ctrl.all_call_sites_or_sinks().filter_map(|cs_or_ds| {
-                let nt: NodeType = (&cs_or_ds).into();
+                let nt: NodeType = cs_or_ds.into();
                 nt.as_data_source()
             }),
         )));
         let sinks = Arc::new(IndexedDomain::from_iter(
             ctrl.all_call_sites_or_sinks()
                 .chain(ctrl.all_sources().filter_map(|src| {
-                    let nt: NodeType = src.into();
+                    let nt: NodeType = src.clone().into();
                     nt.as_call_site_or_data_sink()
                 })),
         ));
@@ -100,9 +100,9 @@ impl CtrlFlowsTo {
         for (sink_idx, sink) in sinks.as_vec().iter_enumerated() {
             let src = match sink {
                 CallSiteOrDataSink::DataSink(DataSink::Argument { function: f, .. }) => {
-                    DataSource::FunctionCall(f.clone())
+                    DataSource::FunctionCall(*f)
                 }
-                CallSiteOrDataSink::CallSite(f) => DataSource::FunctionCall(f.clone()),
+                CallSiteOrDataSink::CallSite(f) => DataSource::FunctionCall(*f),
                 _ => continue,
             };
             let src_idx = if sources.contains(&src) {
@@ -143,10 +143,10 @@ impl CtrlFlowsTo {
         for (src, sinks) in &ctrl.data_flow.0 {
             let src = src.to_index(&sources);
             for sink in sinks {
-                data_flows_to.insert(src, CallSiteOrDataSink::DataSink(sink.clone()));
+                data_flows_to.insert(src, CallSiteOrDataSink::DataSink(*sink));
                 // initialize with flows from DataSource to the DataSink's CallSite
                 if let DataSink::Argument { function, .. } = sink {
-                    data_flows_to.insert(src, CallSiteOrDataSink::CallSite(function.clone()));
+                    data_flows_to.insert(src, CallSiteOrDataSink::CallSite(*function));
                 }
             }
         }
@@ -175,7 +175,7 @@ impl CtrlFlowsTo {
         for (src, callsites) in &ctrl.ctrl_flow.0 {
             let src = src.to_index(&sources);
             for cs in callsites {
-                let new_call_site: CallSiteOrDataSink = cs.clone().into();
+                let new_call_site: CallSiteOrDataSink = (*cs).into();
                 flows_to.insert(src, &new_call_site);
                 // initialize with flows from the DataSource to all of the CallSite's DataSinks
                 for sink in callsites_to_callargs
@@ -214,7 +214,7 @@ fn test_data_flows_to() {
     let controller = ctx.find_by_name("controller").unwrap();
     let src = crate::Node {
         ctrl_id: controller,
-        typ: (&DataSource::Argument(0)).into(),
+        typ: DataSource::Argument(0).into(),
     };
     let sink1 = crate::test_utils::get_sink_node(&ctx, controller, "sink1").unwrap();
     let sink2 = crate::test_utils::get_sink_node(&ctx, controller, "sink2").unwrap();
@@ -228,15 +228,15 @@ fn test_ctrl_flows_to() {
     let controller = ctx.find_by_name("controller_ctrl").unwrap();
     let src_a = crate::Node {
         ctrl_id: controller,
-        typ: (&DataSource::Argument(0)).into(),
+        typ: DataSource::Argument(0).into(),
     };
     let src_b = crate::Node {
         ctrl_id: controller,
-        typ: (&DataSource::Argument(1)).into(),
+        typ: DataSource::Argument(1).into(),
     };
     let src_c = crate::Node {
         ctrl_id: controller,
-        typ: (&DataSource::Argument(2)).into(),
+        typ: DataSource::Argument(2).into(),
     };
     let cs1 = crate::test_utils::get_callsite_node(&ctx, controller, "sink1").unwrap();
     let cs2 = crate::test_utils::get_callsite_node(&ctx, controller, "sink2").unwrap();
@@ -253,11 +253,11 @@ fn test_flows_to() {
     let controller = ctx.find_by_name("controller_data_ctrl").unwrap();
     let src_a = crate::Node {
         ctrl_id: controller,
-        typ: (&DataSource::Argument(0)).into(),
+        typ: DataSource::Argument(0).into(),
     };
     let src_b = crate::Node {
         ctrl_id: controller,
-        typ: (&DataSource::Argument(1)).into(),
+        typ: DataSource::Argument(1).into(),
     };
     let sink = crate::test_utils::get_sink_node(&ctx, controller, "sink1").unwrap();
     let cs = crate::test_utils::get_callsite_node(&ctx, controller, "sink1").unwrap();

--- a/crates/paralegal-policy/src/test_utils.rs
+++ b/crates/paralegal-policy/src/test_utils.rs
@@ -23,7 +23,7 @@ pub fn get_callsite_or_datasink_node<'a>(
     ctx: &'a Context,
     controller: ControllerId,
     name: &'a str,
-) -> Option<Node<'a>> {
+) -> Option<Node> {
     Some(get_callsite_node(ctx, controller, name).unwrap_or(get_sink_node(ctx, controller, name)?))
 }
 
@@ -31,14 +31,14 @@ pub fn get_callsite_node<'a>(
     ctx: &'a Context,
     controller: ControllerId,
     name: &'a str,
-) -> Option<Node<'a>> {
+) -> Option<Node> {
     let name = Identifier::new_intern(name);
     let node = ctx.desc().controllers[&controller]
         .call_sites()
         .find(|callsite| ctx.desc().def_info[&callsite.function].name == name)?;
     Some(crate::Node {
         ctrl_id: controller,
-        typ: node.into(),
+        typ: node.clone().into(),
     })
 }
 
@@ -46,7 +46,7 @@ pub fn get_sink_node<'a>(
     ctx: &'a Context,
     controller: ControllerId,
     name: &'a str,
-) -> Option<Node<'a>> {
+) -> Option<Node> {
     let name = Identifier::new_intern(name);
     let node = ctx.desc().controllers[&controller]
         .data_sinks()
@@ -58,6 +58,6 @@ pub fn get_sink_node<'a>(
         })?;
     Some(crate::Node {
         ctrl_id: controller,
-        typ: node.into(),
+        typ: node.clone().into(),
     })
 }

--- a/crates/paralegal-spdg/src/lib.rs
+++ b/crates/paralegal-spdg/src/lib.rs
@@ -444,7 +444,7 @@ impl<X, Y> Relation<X, Y> {
 }
 
 /// A global location in the program where a function is being called.
-#[derive(Hash, Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
+#[derive(Hash, Eq, PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct CallSite {
     /// The location of the call.
     pub location: GlobalLocation,
@@ -589,7 +589,7 @@ impl From<CallSite> for DataSource {
 /// A representation of something that can receive data from the flow.
 ///
 /// [`Self::as_argument`] is provided for convenience of matching.
-#[derive(Hash, PartialEq, Eq, Clone, Serialize, Deserialize, Debug)]
+#[derive(Hash, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Debug)]
 pub enum DataSink {
     Argument { function: CallSite, arg_slot: usize },
     Return,
@@ -741,17 +741,11 @@ impl Ctrl {
             .flatten()
             .flat_map(|s| match s {
                 DataSink::Argument { function, .. } => {
-                    vec![function.clone().into(), s.clone().into()]
+                    vec![(*function).into(), (*s).into()]
                 }
-                _ => vec![s.clone().into()],
+                _ => vec![(*s).into()],
             })
-            .chain(
-                self.ctrl_flow
-                    .0
-                    .values()
-                    .flatten()
-                    .map(|cs| cs.clone().into()),
-            )
+            .chain(self.ctrl_flow.0.values().flatten().map(|cs| (*cs).into()))
             .dedup()
     }
 }


### PR DESCRIPTION
## What Changed?

Change `NodeType` so that it owns its info instead of holding references.

## Why Does It Need To?

The main benefit of this is that we can construct `NodeType`s rather than only being able to refer to pieces of the `ProgramDescription`, which gives us more flexibility to, for example, create a new `CallArgument` from just the `CallSite` (and maybe auxiliary knowledge like how many arguments the function has). 

A more urgent concern is that https://github.com/brownsys/paralegal/pull/118 relies on this.

This uses more memory than the previous implementation. A proposal to address this is [here](https://www.notion.so/justus-adam/Shrinking-the-size-of-a-NodeType-77c75eeb08514b22844d0579c10baac3?pvs=4).

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [x] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [ ] Documentation in Notion has been updated
- [ ] Tests for new behaviors are provided
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.