### PR TITLE
Implement selection of analysis target via command line.

### DIFF
--- a/crates/paralegal-flow/src/args.rs
+++ b/crates/paralegal-flow/src/args.rs
@@ -429,7 +429,8 @@ impl MarkerControl {
 pub struct AnalysisCtrl {
     /// Target this function as analysis target. Command line version of
     /// `#[paralegal::analyze]`). Must be a full rust path and resolve to a
-    /// function. May be specified multiple times.
+    /// function. May be specified multiple times and multiple, comma separated
+    /// paths may be supplied at the same time.
     #[clap(long)]
     analyze: Vec<String>,
     /// Disables all recursive analysis (both paralegal_flow's inlining as well as
@@ -522,6 +523,7 @@ impl PruningStrategy {
 }
 
 impl AnalysisCtrl {
+    /// Externally (via command line) selected analysis targets
     pub fn selected_targets(&self) -> &[String] {
         &self.analyze
     }

--- a/crates/paralegal-flow/src/args.rs
+++ b/crates/paralegal-flow/src/args.rs
@@ -63,12 +63,12 @@ impl TryFrom<ClapArgs> for Args {
         anactrl.analyze = anactrl
             .analyze
             .iter()
-            .flat_map(|s| s.split(",").map(ToOwned::to_owned))
+            .flat_map(|s| s.split(',').map(ToOwned::to_owned))
             .collect();
         if let Some(from_env) = env_var_expect_unicode("PARALEGAL_ANALYZE")? {
             anactrl
                 .analyze
-                .extend(from_env.split(",").map(ToOwned::to_owned));
+                .extend(from_env.split(',').map(ToOwned::to_owned));
         }
         let build_config_file = std::path::Path::new("Paralegal.toml");
         let build_config = if build_config_file.exists() {

--- a/crates/paralegal-flow/src/discover.rs
+++ b/crates/paralegal-flow/src/discover.rs
@@ -66,6 +66,10 @@ impl<'tcx> CollectingVisitor<'tcx> {
             .iter()
             .filter_map(|path| {
                 let def_id = expect_resolve_string_to_def_id(tcx, path, opts.relaxed())?;
+                if !def_id.is_local() {
+                    tcx.sess.span_err(tcx.def_span(def_id), "found an external function as analysis target. Analysis targets are required to be local.");
+                    return None;
+                }
                 Some(FnToAnalyze {
                     def_id,
                     name: tcx.opt_item_ident(def_id).unwrap(),

--- a/crates/paralegal-flow/src/utils/resolve.rs
+++ b/crates/paralegal-flow/src/utils/resolve.rs
@@ -59,11 +59,7 @@ impl Res {
 /// that `def_path_res` is used. In the case of errors they are reported to the
 /// user and `None` is returned so the caller has the option of making progress
 /// before exiting.
-pub fn expect_resolve_string_to_def_id<'a>(
-    tcx: TyCtxt,
-    path: &'a str,
-    relaxed: bool,
-) -> Option<DefId> {
+pub fn expect_resolve_string_to_def_id(tcx: TyCtxt, path: &str, relaxed: bool) -> Option<DefId> {
     let segment_vec = path.split("::").collect::<Vec<_>>();
     let res = def_path_res(tcx, &segment_vec)
         .map_err(|e| tcx.sess.err(format!("Could not resolve {path}: {e:?}")))

--- a/crates/paralegal-flow/src/utils/resolve.rs
+++ b/crates/paralegal-flow/src/utils/resolve.rs
@@ -55,6 +55,33 @@ impl Res {
     }
 }
 
+/// A small helper wrapper around [`def_path_res`] that represents a common way
+/// that `def_path_res` is used. In the case of errors they are reported to the
+/// user and `None` is returned so the caller has the option of making progress
+/// before exiting.
+pub fn expect_resolve_string_to_def_id<'a>(
+    tcx: TyCtxt,
+    path: &'a str,
+    relaxed: bool,
+) -> Option<DefId> {
+    let segment_vec = path.split("::").collect::<Vec<_>>();
+    let res = def_path_res(tcx, &segment_vec)
+        .map_err(|e| tcx.sess.err(format!("Could not resolve {path}: {e:?}")))
+        .ok()?;
+    match res {
+        Res::Def(_, did) => Some(did),
+        other => {
+            let msg = format!("expected {path} to resolve to an item, got {other:?}");
+            if relaxed {
+                tcx.sess.warn(msg);
+            } else {
+                tcx.sess.err(msg);
+            };
+            None
+        }
+    }
+}
+
 /// Lifted from `clippy_utils`
 pub fn def_path_res<'a>(tcx: TyCtxt, path: &[&'a str]) -> Result<Res, ResolutionError<'a>> {
     fn item_child_by_name<'a>(


### PR DESCRIPTION
## What Changed?

Adds a new command line and environment argument `--analyze` and `PARALEGAL_ANALYZE` which select an analysis target, the same as the inline `#[paralegal::analyze]` does.

The target is required to resolve to a local function item.

The command line argument may be specified multiple times. Both command line and env variable admit multiple, comma-separated paths, e.g. a format `std::vec::Vec::push,std::env::var`.

## Why Does It Need To?

This allow users to apply paralegal to their project without *any* source-level modifications.

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [x] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [ ] Documentation in Notion has been updated
- [ ] Tests for new behaviors are provided
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.