### PR TITLE
Statistics in policy and analyzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,6 +809,7 @@ dependencies = [
  "chrono",
  "clap",
  "dot",
+ "enum-map",
  "flowistry",
  "humantime",
  "indexical",

--- a/crates/paralegal-flow/Cargo.toml
+++ b/crates/paralegal-flow/Cargo.toml
@@ -41,6 +41,7 @@ num-traits = "0.2"
 petgraph = { workspace = true }
 humantime = "2"
 strum = { version = "0.25", features = ["derive"] }
+enum-map = "2.7"
 
 
 #dot = "0.1"

--- a/crates/paralegal-flow/src/ana/mod.rs
+++ b/crates/paralegal-flow/src/ana/mod.rs
@@ -11,12 +11,12 @@ use crate::{
     rust::{hir::def, *},
     ty::TyKind,
     utils::*,
-    DefId, HashMap, HashSet, LogLevelConfig, MarkerCtx, Symbol,
+    DefId, HashMap, HashSet, LogLevelConfig, MarkerCtx, Stat, Symbol,
 };
 use paralegal_spdg::Node;
 
-use std::borrow::Cow;
 use std::rc::Rc;
+use std::{borrow::Cow, time::Instant};
 
 use anyhow::{anyhow, Result};
 use either::Either;
@@ -33,18 +33,25 @@ mod inline_judge;
 /// Read-only database of information the analysis needs.
 ///
 /// [`Self::analyze`] serves as the main entrypoint to SPDG generation.
-pub struct SPDGGenerator<'tcx> {
+pub struct SPDGGenerator<'tcx, 'st> {
     pub marker_ctx: MarkerCtx<'tcx>,
     pub opts: &'static crate::Args,
     pub tcx: TyCtxt<'tcx>,
+    stats: &'st mut crate::Stats,
 }
 
-impl<'tcx> SPDGGenerator<'tcx> {
-    pub fn new(marker_ctx: MarkerCtx<'tcx>, opts: &'static crate::Args, tcx: TyCtxt<'tcx>) -> Self {
+impl<'tcx, 'st> SPDGGenerator<'tcx, 'st> {
+    pub fn new(
+        marker_ctx: MarkerCtx<'tcx>,
+        opts: &'static crate::Args,
+        tcx: TyCtxt<'tcx>,
+        stats: &'st mut crate::Stats,
+    ) -> Self {
         Self {
             marker_ctx,
             opts,
             tcx,
+            stats,
         }
     }
 
@@ -53,12 +60,12 @@ impl<'tcx> SPDGGenerator<'tcx> {
     ///
     /// Main work for a single target is performed by [`GraphConverter`].
     fn handle_target(
-        &self,
+        &mut self,
         //_hash_verifications: &mut HashVerifications,
         target: FnToAnalyze,
         known_def_ids: &mut impl Extend<DefId>,
     ) -> Result<(Endpoint, SPDG)> {
-        debug!("Handling target {}", target.name());
+        info!("Handling target {}", self.tcx.def_path_str(target.def_id));
         let local_def_id = target.def_id.expect_local();
 
         let converter = GraphConverter::new_with_flowistry(self, known_def_ids, target)?;
@@ -72,7 +79,7 @@ impl<'tcx> SPDGGenerator<'tcx> {
     /// other setup necessary for the flow graph creation.
     ///
     /// Should only be called after the visit.
-    pub fn analyze(&self, targets: Vec<FnToAnalyze>) -> Result<ProgramDescription> {
+    pub fn analyze(&mut self, targets: Vec<FnToAnalyze>) -> Result<ProgramDescription> {
         if let LogLevelConfig::Targeted(s) = self.opts.debug() {
             assert!(
                 targets.iter().any(|target| target.name().as_str() == s),
@@ -100,7 +107,12 @@ impl<'tcx> SPDGGenerator<'tcx> {
                 })
             })
             .collect::<Result<HashMap<Endpoint, SPDG>>>()
-            .map(|controllers| self.make_program_description(controllers, &known_def_ids))
+            .map(|controllers| {
+                let start = Instant::now();
+                let desc = self.make_program_description(controllers, &known_def_ids);
+                self.stats.record(Stat::Conversion, start.elapsed());
+                desc
+            })
     }
 
     /// Given the PDGs and a record of all [`DefId`]s we've seen, compile
@@ -210,10 +222,10 @@ fn default_index() -> <SPDGImpl as GraphBase>::NodeId {
 ///
 /// Intended usage is to call [`Self::new_with_flowistry`] to initialize, then
 /// [`Self::make_spdg`] to convert.
-struct GraphConverter<'tcx, 'a, C> {
+struct GraphConverter<'tcx, 'a, 'st, C> {
     // Immutable information
     /// The parent generator
-    generator: &'a SPDGGenerator<'tcx>,
+    generator: &'a mut SPDGGenerator<'tcx, 'st>,
     /// Information about the function this PDG belongs to
     target: FnToAnalyze,
     /// The flowistry graph we are converting
@@ -234,15 +246,19 @@ struct GraphConverter<'tcx, 'a, C> {
     spdg: SPDGImpl,
 }
 
-impl<'a, 'tcx, C: Extend<DefId>> GraphConverter<'tcx, 'a, C> {
+impl<'a, 'st, 'tcx, C: Extend<DefId>> GraphConverter<'tcx, 'a, 'st, C> {
     /// Initialize a new converter by creating an initial PDG using flowistry.
     fn new_with_flowistry(
-        generator: &'a SPDGGenerator<'tcx>,
+        generator: &'a mut SPDGGenerator<'tcx, 'st>,
         known_def_ids: &'a mut C,
         target: FnToAnalyze,
     ) -> Result<Self> {
         let local_def_id = target.def_id.expect_local();
+        let start = Instant::now();
         let dep_graph = Rc::new(Self::create_flowistry_graph(generator, local_def_id)?);
+        generator
+            .stats
+            .record(crate::Stat::Flowistry, start.elapsed());
 
         if generator.opts.dbg().dump_flowistry_pdg() {
             dep_graph.generate_graphviz(format!("{}.flowistry-pdg.pdf", target.name))?
@@ -491,7 +507,7 @@ impl<'a, 'tcx, C: Extend<DefId>> GraphConverter<'tcx, 'a, C> {
     /// Create an initial flowistry graph for the function identified by
     /// `local_def_id`.
     fn create_flowistry_graph(
-        generator: &SPDGGenerator<'tcx>,
+        generator: &SPDGGenerator<'tcx, '_>,
         local_def_id: LocalDefId,
     ) -> Result<DepGraph<'tcx>> {
         let tcx = generator.tcx;
@@ -527,9 +543,13 @@ impl<'a, 'tcx, C: Extend<DefId>> GraphConverter<'tcx, 'a, C> {
 
     /// Consume the generator and compile the [`SPDG`].
     fn make_spdg(mut self) -> SPDG {
+        let start = Instant::now();
         let markers = self.make_spdg_impl();
         let arguments = self.determine_arguments();
         let return_ = self.determine_return();
+        self.generator
+            .stats
+            .record(Stat::Conversion, start.elapsed());
         SPDG {
             graph: self.spdg,
             name: Identifier::new(self.target.name()),

--- a/crates/paralegal-flow/src/lib.rs
+++ b/crates/paralegal-flow/src/lib.rs
@@ -63,13 +63,16 @@ pub mod rust {
 }
 
 use args::{ClapArgs, LogLevelConfig};
-use desc::utils::write_sep;
+use desc::utils::{write_sep, TruncatedHumanTime};
 use rust::*;
 
 use rustc_plugin::CrateFilter;
 use rustc_utils::mir::borrowck_facts;
 pub use std::collections::{HashMap, HashSet};
-use std::fmt::Display;
+use std::{
+    fmt::Display,
+    time::{Duration, Instant},
+};
 
 // This import is sort of special because it comes from the private rustc
 // dependencies and not from our `Cargo.toml`.
@@ -122,6 +125,45 @@ struct ArgWrapper {
 
 struct Callbacks {
     opts: &'static Args,
+    stats: Stats,
+    start: Instant,
+}
+
+#[derive(Debug, Clone, Copy, strum::AsRefStr, PartialEq, Eq, enum_map::Enum)]
+pub enum Stat {
+    Rustc,
+    Flowistry,
+    Conversion,
+    Serialization,
+}
+
+pub struct Stats(enum_map::EnumMap<Stat, Option<Duration>>);
+
+impl Stats {
+    pub fn record(&mut self, stat: Stat, duration: Duration) {
+        *self.0[stat].get_or_insert(Duration::ZERO) += duration
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (Stat, Option<Duration>)> + '_ {
+        self.0.iter().map(|(k, v)| (k, *v))
+    }
+}
+
+impl Default for Stats {
+    fn default() -> Self {
+        Self(enum_map::enum_map! { _ => None })
+    }
+}
+
+impl Display for Stats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (s, dur) in self.iter() {
+            if let Some(dur) = dur {
+                write!(f, "{}: {}", s.as_ref(), TruncatedHumanTime::from(dur))?;
+            }
+        }
+        Ok(())
+    }
 }
 
 struct NoopCallbacks {}
@@ -143,12 +185,14 @@ impl rustc_driver::Callbacks for Callbacks {
         _compiler: &rustc_interface::interface::Compiler,
         queries: &'tcx rustc_interface::Queries<'tcx>,
     ) -> rustc_driver::Compilation {
+        self.stats.record(Stat::Rustc, self.start.elapsed());
         queries
             .global_ctxt()
             .unwrap()
             .enter(|tcx| {
                 tcx.sess.abort_if_errors();
-                let desc = discover::CollectingVisitor::new(tcx, self.opts).run()?;
+                let desc =
+                    discover::CollectingVisitor::new(tcx, self.opts, &mut self.stats).run()?;
                 info!("All elems walked");
                 tcx.sess.abort_if_errors();
 
@@ -157,6 +201,7 @@ impl rustc_driver::Callbacks for Callbacks {
                     paralegal_spdg::dot::dump(&desc, out).unwrap();
                 }
 
+                let ser = Instant::now();
                 serde_json::to_writer(
                     &mut std::fs::OpenOptions::new()
                         .truncate(true)
@@ -167,6 +212,9 @@ impl rustc_driver::Callbacks for Callbacks {
                     &desc,
                 )
                 .unwrap();
+                self.stats.record(Stat::Serialization, ser.elapsed());
+
+                println!("Analysis finished with timing: {}", self.stats);
 
                 anyhow::Ok(if self.opts.abort_after_analysis() {
                     rustc_driver::Compilation::Stop
@@ -360,6 +408,14 @@ impl rustc_plugin::RustcPlugin for DfppPlugin {
             "Arguments: {}",
             Print(|f| write_sep(f, " ", &compiler_args, Display::fmt))
         );
-        rustc_driver::RunCompiler::new(&compiler_args, &mut Callbacks { opts }).run()
+        rustc_driver::RunCompiler::new(
+            &compiler_args,
+            &mut Callbacks {
+                opts,
+                stats: Default::default(),
+                start: Instant::now(),
+            },
+        )
+        .run()
     }
 }

--- a/crates/paralegal-policy/src/lib.rs
+++ b/crates/paralegal-policy/src/lib.rs
@@ -53,9 +53,11 @@ extern crate core;
 
 use anyhow::{ensure, Result};
 pub use paralegal_spdg;
+use paralegal_spdg::utils::TruncatedHumanTime;
 pub use paralegal_spdg::{
     traverse::EdgeSelection, GlobalNode, IntoIterGlobalNodes, ProgramDescription,
 };
+use std::time::{Duration, Instant};
 use std::{
     fs::File,
     path::{Path, PathBuf},
@@ -76,6 +78,44 @@ pub use self::{
     flows_to::CtrlFlowsTo,
     flows_to::DataAndControlInfluencees,
 };
+
+#[derive(Clone, Debug)]
+/// Statistics about the runtime of the various parts of a policy.
+pub struct Stats {
+    /// Runtime of the `paralegal-flow` command
+    pub analysis: Option<Duration>,
+    /// How long it took to create the indices
+    pub context_contruction: Duration,
+    /// How long the policy runs
+    pub policy: Duration,
+}
+
+impl std::fmt::Display for Stats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Analysis: ")?;
+        if let Some(ana) = self.analysis {
+            TruncatedHumanTime::from(ana).fmt(f)?;
+        } else {
+            f.write_str("no measurement")?;
+        }
+        write!(
+            f,
+            ", Index Creation: {}, Policy Execution: {}",
+            TruncatedHumanTime::from(self.context_contruction),
+            TruncatedHumanTime::from(self.policy)
+        )
+    }
+}
+
+/// Result of running a policy
+pub struct PolicyReturn<A> {
+    /// If the policy wants to return additional data, this is it
+    pub result: A,
+    /// Did the policy succeed.
+    pub success: bool,
+    /// Runtime statistics
+    pub stats: Stats,
+}
 
 /// Configuration of the `cargo paralegal-flow` command.
 ///
@@ -132,9 +172,12 @@ impl SPDGGenCommand {
     ///
     /// To run yor properties on the results see [`GraphLocation`].
     pub fn run(&mut self, dir: impl AsRef<Path>) -> Result<GraphLocation> {
+        let start = Instant::now();
         let status = self.0.current_dir(dir.as_ref()).status()?;
         ensure!(status.success(), "Compilation failed");
-        Ok(GraphLocation::std(dir.as_ref()))
+        let mut loc = GraphLocation::std(dir.as_ref());
+        loc.construction_time = Some(start.elapsed());
+        Ok(loc)
     }
 }
 
@@ -144,33 +187,56 @@ impl SPDGGenCommand {
 /// Can be created programmatically and automatically by running
 /// [`SPDGGenCommand::run`] or you can create one manually if you can `cargo
 /// paralegal-flow` by hand with [`Self::custom`].
-pub struct GraphLocation(PathBuf);
+pub struct GraphLocation {
+    path: PathBuf,
+    construction_time: Option<Duration>,
+}
 
 impl GraphLocation {
     /// Use the default graph file name in the specified directory.
     pub fn std(dir: impl AsRef<Path>) -> Self {
-        Self(dir.as_ref().join(paralegal_spdg::FLOW_GRAPH_OUT_NAME))
+        Self {
+            path: dir.as_ref().join(paralegal_spdg::FLOW_GRAPH_OUT_NAME),
+            construction_time: None,
+        }
     }
 
     /// Use a completely custom path (directory and file name).
     pub fn custom(path: PathBuf) -> Self {
-        Self(path)
+        Self {
+            path,
+            construction_time: None,
+        }
     }
 
     /// Builds a context, then runs the property.
     ///
     /// Emits any recorded diagnostic messages to stdout and aborts the program
     /// if they were severe enough.
-    pub fn with_context<A>(&self, prop: impl FnOnce(Arc<Context>) -> Result<A>) -> Result<A> {
+    pub fn with_context<A>(
+        &self,
+        prop: impl FnOnce(Arc<Context>) -> Result<A>,
+    ) -> Result<PolicyReturn<A>> {
         let ctx = Arc::new(self.build_context()?);
+
         assert_warning!(
             ctx,
             !ctx.desc().controllers.is_empty(),
             "No controllers found. Your policy is likely to be vacuous."
         );
+        let start = Instant::now();
         let result = prop(ctx.clone())?;
-        ctx.emit_diagnostics_may_exit(std::io::stdout())?;
-        Ok(result)
+
+        let success = ctx.emit_diagnostics(std::io::stdout())?;
+        Ok(PolicyReturn {
+            success,
+            result,
+            stats: Stats {
+                analysis: ctx.stats.0,
+                context_contruction: ctx.stats.1,
+                policy: start.elapsed(),
+            },
+        })
     }
 
     /// Read and parse this graph file, returning a [`Context`] suitable for
@@ -182,12 +248,14 @@ impl GraphLocation {
         let _ = simple_logger::init_with_env();
 
         let desc = {
-            let mut f = File::open(&self.0)?;
+            let mut f = File::open(&self.path)?;
             anyhow::Context::with_context(
                 serde_json::from_reader::<_, ProgramDescription>(&mut f),
-                || format!("Reading SPDG (JSON) from {}", self.0.display()),
+                || format!("Reading SPDG (JSON) from {}", self.path.display()),
             )?
         };
-        Ok(Context::new(desc))
+        let mut ctx = Context::new(desc);
+        ctx.stats.0 = self.construction_time;
+        Ok(ctx)
     }
 }

--- a/crates/paralegal-spdg/src/utils.rs
+++ b/crates/paralegal-spdg/src/utils.rs
@@ -97,3 +97,53 @@ pub mod serde_map_via_vec {
         Ok(Vec::deserialize(deserializer)?.into_iter().collect())
     }
 }
+
+pub struct TruncatedHumanTime(std::time::Duration);
+
+impl From<std::time::Duration> for TruncatedHumanTime {
+    fn from(value: std::time::Duration) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Display for TruncatedHumanTime {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        const SECS_PER_MIN: u64 = 60;
+        const MINS_PER_H: u64 = 60;
+        const H_PER_D: u64 = 24;
+        const MILLIS_PER_SEC: u128 = 1000;
+        const MICROS_PER_MILLIS: u128 = 1000;
+        const NANOS_PER_MICRO: u128 = 1000;
+        let secs = self.0.as_secs();
+        let mins = secs / SECS_PER_MIN;
+        let hs = mins / MINS_PER_H;
+        let days = hs / H_PER_D;
+        macro_rules! try_two {
+            ($larger:expr, $letter1:expr, $smaller:expr, $letter2:expr, $multiplier:expr $(,)?) => {
+                if $larger != 0 {
+                    let small = $smaller - ($larger * $multiplier);
+                    return write!(f, "{}{} {small}{}", $larger, $letter1, $letter2);
+                }
+            };
+        }
+        try_two!(days, 'd', hs, 'h', H_PER_D);
+        try_two!(hs, 'h', mins, "min", MINS_PER_H);
+        try_two!(mins, "min", secs, 's', SECS_PER_MIN);
+        try_two!(secs as u128, 's', self.0.as_millis(), "ms", MILLIS_PER_SEC);
+        try_two!(
+            self.0.as_millis(),
+            "ms",
+            self.0.as_micros(),
+            "μs",
+            MICROS_PER_MILLIS,
+        );
+        try_two!(
+            self.0.as_micros(),
+            "μs",
+            self.0.as_nanos(),
+            "ns",
+            NANOS_PER_MICRO,
+        );
+        write!(f, "{}ns", self.0.as_nanos())
+    }
+}


### PR DESCRIPTION
## What Changed?

This adds lightweight statistics collection about the time spent in rustc, analyzing, converting graphs, serializing, precomputing the context and running the policy.

## Why Does It Need To?

This allows for a rudimentary type of profiling.

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [ ] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [ ] Documentation in Notion has been updated
- [ ] Tests for new behaviors are provided
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.