### PR TITLE
Clear dir before installing rustc docs

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -223,3 +223,11 @@ mv ${source_path} docs/compiler
 [tasks.get-rustc-docs]
 command = "rustup"
 args = ["component", "add", "rustc-docs"]
+dependencies = ["clean-rustc-docs-location"]
+
+[tasks.clean-rustc-docs-location]
+command = "rm"
+args = [
+    "-f",
+    "${RUSTUP_HOME}/toolchains/${RUSTUP_TOOLCHAIN}/share/doc/rust/html/rustc",
+]


### PR DESCRIPTION
## What Changed?

Remove the `${RUSTUP_HOME}/toolchains/${RUSTUP_TOOLCHAIN}/share/doc/rust/html/rustc` directory before trying to install the rustc rustdocs in the documentation job.

## Why Does It Need To?

Should prevent the failure we observed in the last documentation build job.

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [x] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [x] Documentation in Notion has been updated
- [x] Tests for new behaviors are provided
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.