### PR TITLE
Support for CodeLLDB debugger

### DIFF
--- a/crates/paralegal-flow/src/args.rs
+++ b/crates/paralegal-flow/src/args.rs
@@ -53,6 +53,7 @@ impl TryFrom<ClapArgs> for Args {
             marker_control,
             cargo_args,
             trace,
+            attach_to_debugger,
         } = value;
         let mut dump: DumpArgs = dump.into();
         if let Some(from_env) = env_var_expect_unicode("PARALEGAL_DUMP")? {
@@ -102,8 +103,15 @@ impl TryFrom<ClapArgs> for Args {
             build_config,
             marker_control,
             cargo_args,
+            attach_to_debugger,
         })
     }
+}
+
+#[derive(serde::Serialize, serde::Deserialize, clap::ValueEnum, Clone, Copy)]
+pub enum Debugger {
+    /// The CodeLLDB debugger. Learn more at <https://github.com/vadimcn/codelldb/blob/v1.10.0/MANUAL.md>.
+    CodeLldb,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -115,10 +123,12 @@ pub struct Args {
     result_path: std::path::PathBuf,
     /// Emit warnings instead of aborting the analysis on sanity checks
     relaxed: bool,
-
+    /// Target a specific package
     target: Option<String>,
     /// Abort the compilation after finishing the analysis
     abort_after_analysis: bool,
+    /// Make the compiler attach to a debugger
+    attach_to_debugger: Option<Debugger>,
     /// Additional arguments on marker assignment and discovery
     marker_control: MarkerControl,
     /// Additional arguments that control the flow analysis specifically
@@ -160,12 +170,15 @@ pub struct ClapArgs {
     /// Emit warnings instead of aborting the analysis on sanity checks
     #[clap(long, env = "PARALEGAL_RELAXED")]
     relaxed: bool,
-
+    /// Run paralegal only on this crate
     #[clap(long, env = "PARALEGAL_TARGET")]
     target: Option<String>,
     /// Abort the compilation after finishing the analysis
     #[clap(long, env)]
     abort_after_analysis: bool,
+    /// Attach to a debugger before running the analyses
+    #[clap(long)]
+    attach_to_debugger: Option<Debugger>,
     /// Additional arguments that control the flow analysis specifically
     #[clap(flatten, next_help_heading = "Flow Analysis")]
     anactrl: ClapAnalysisCtrl,
@@ -346,6 +359,10 @@ impl Args {
 
     pub fn cargo_args(&self) -> &[String] {
         &self.cargo_args
+    }
+
+    pub fn attach_to_debugger(&self) -> Option<Debugger> {
+        self.attach_to_debugger
     }
 }
 


### PR DESCRIPTION
## What Changed?

Adds the option to attach remotely to a CodeLLDB debugging session directly from within paralegal-flow. It uses the mechanism described [here](https://github.com/vadimcn/codelldb/blob/v1.10.0/MANUAL.md)

Adds a `--attach-to-debugger` command line option which accepts the name of a debugger to initiate a session with. Currently only the value `code-lldb` is accepted. It will attach to a debugger for every analysis target. Skipped crates (where regular rustc runs) do not attach.

## Why Does It Need To?

Vastly simplifies the process of using a debugger with the tool.

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [x] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [ ] Documentation in Notion has been updated
- [ ] Tests for new behaviors are provided
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.