### PR TITLE
Enable plugin profiling via environment variable

### DIFF
--- a/crates/paralegal-flow/src/lib.rs
+++ b/crates/paralegal-flow/src/lib.rs
@@ -363,6 +363,17 @@ impl rustc_plugin::RustcPlugin for DfppPlugin {
         }
         let opts = Box::leak(Box::new(plugin_args));
 
+        const RERUN_VAR: &str = "RERUN_WITH_PROFILER";
+        if let Ok(debugger) = std::env::var(RERUN_VAR) {
+            info!("Restarting with debugger '{debugger}'");
+            let mut dsplit = debugger.split(' ');
+            let mut cmd = std::process::Command::new(dsplit.next().unwrap());
+            cmd.args(dsplit)
+                .args(std::env::args())
+                .env_remove(RERUN_VAR);
+            std::process::exit(cmd.status().unwrap().code().unwrap_or(0));
+        }
+
         compiler_args.extend([
             "--cfg".into(),
             "paralegal".into(),


### PR DESCRIPTION
## What Changed?

Adds support for a `RERUN_WITH_PROFILER` environment variable. When supplied with the name and argument for a profiler binary setting this variable causes the plugin invoke the profiler with those arguments and all other environment variables and arguments passed.

## Why Does It Need To?

This allows to easily create profiles for any run of the tool, even if we are working on a crate with dependencies that need to be compiled first.

Caveat: It will currently call the profiler for every run on an analysis target crate.

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [x] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [x] Documentation in Notion has been updated
- [ ] Tests for new behaviors are provided
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.