### PR TITLE
Single-compile testing framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,12 +1110,12 @@ name = "rustc_plugin"
 version = "0.7.4-nightly-2023-08-25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1348edfa020dbe4807a4d99272332dadcbbedff6b587accb95faefe20d2c7129"
-replace = "rustc_plugin 0.7.4-nightly-2023-08-25 (git+https://github.com/JustusAdam/rustc_plugin?rev=aa83f5740fa7eb5b8e3e1ee417b29536e87cc864)"
+replace = "rustc_plugin 0.7.4-nightly-2023-08-25 (git+https://github.com/JustusAdam/rustc_plugin?rev=d4fefb5c0344cdf4812b4877d5b03cb19a2c4672)"
 
 [[package]]
 name = "rustc_plugin"
 version = "0.7.4-nightly-2023-08-25"
-source = "git+https://github.com/JustusAdam/rustc_plugin?rev=aa83f5740fa7eb5b8e3e1ee417b29536e87cc864#aa83f5740fa7eb5b8e3e1ee417b29536e87cc864"
+source = "git+https://github.com/JustusAdam/rustc_plugin?rev=d4fefb5c0344cdf4812b4877d5b03cb19a2c4672#d4fefb5c0344cdf4812b4877d5b03cb19a2c4672"
 dependencies = [
  "cargo_metadata",
  "log",
@@ -1136,12 +1136,12 @@ name = "rustc_utils"
 version = "0.7.4-nightly-2023-08-25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09428c7086894369685cca54a516acc0f0ab6d0e5a628c094ba83bfddaf1aedf"
-replace = "rustc_utils 0.7.4-nightly-2023-08-25 (git+https://github.com/JustusAdam/rustc_plugin?rev=aa83f5740fa7eb5b8e3e1ee417b29536e87cc864)"
+replace = "rustc_utils 0.7.4-nightly-2023-08-25 (git+https://github.com/JustusAdam/rustc_plugin?rev=d4fefb5c0344cdf4812b4877d5b03cb19a2c4672)"
 
 [[package]]
 name = "rustc_utils"
 version = "0.7.4-nightly-2023-08-25"
-source = "git+https://github.com/JustusAdam/rustc_plugin?rev=aa83f5740fa7eb5b8e3e1ee417b29536e87cc864#aa83f5740fa7eb5b8e3e1ee417b29536e87cc864"
+source = "git+https://github.com/JustusAdam/rustc_plugin?rev=d4fefb5c0344cdf4812b4877d5b03cb19a2c4672#d4fefb5c0344cdf4812b4877d5b03cb19a2c4672"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,6 @@ debug = true
 
 "rustc_utils:0.7.4-nightly-2023-08-25" = { git = "https://github.com/JustusAdam/rustc_plugin", rev = "d4fefb5c0344cdf4812b4877d5b03cb19a2c4672", features = [
     "indexical",
+    "test",
 ] }
 "rustc_plugin:0.7.4-nightly-2023-08-25" = { git = "https://github.com/JustusAdam/rustc_plugin", rev = "d4fefb5c0344cdf4812b4877d5b03cb19a2c4672" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,5 @@ debug = true
 # "rustc_utils:0.7.4-nightly-2023-08-25" = { path = "../rustc_plugin/crates/rustc_utils" }
 # "rustc_plugin:0.7.4-nightly-2023-08-25" = { path = "../rustc_plugin/crates/rustc_plugin" }
 
-"rustc_utils:0.7.4-nightly-2023-08-25" = { git = "https://github.com/JustusAdam/rustc_plugin", rev = "d4fefb5c0344cdf4812b4877d5b03cb19a2c4672", features = [
-    "indexical",
-    "test",
-] }
+"rustc_utils:0.7.4-nightly-2023-08-25" = { git = "https://github.com/JustusAdam/rustc_plugin", rev = "d4fefb5c0344cdf4812b4877d5b03cb19a2c4672" }
 "rustc_plugin:0.7.4-nightly-2023-08-25" = { git = "https://github.com/JustusAdam/rustc_plugin", rev = "d4fefb5c0344cdf4812b4877d5b03cb19a2c4672" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ debug = true
 # "rustc_utils:0.7.4-nightly-2023-08-25" = { path = "../rustc_plugin/crates/rustc_utils" }
 # "rustc_plugin:0.7.4-nightly-2023-08-25" = { path = "../rustc_plugin/crates/rustc_plugin" }
 
-"rustc_utils:0.7.4-nightly-2023-08-25" = { git = "https://github.com/JustusAdam/rustc_plugin", rev = "aa83f5740fa7eb5b8e3e1ee417b29536e87cc864", features = [
+"rustc_utils:0.7.4-nightly-2023-08-25" = { git = "https://github.com/JustusAdam/rustc_plugin", rev = "d4fefb5c0344cdf4812b4877d5b03cb19a2c4672", features = [
     "indexical",
 ] }
-"rustc_plugin:0.7.4-nightly-2023-08-25" = { git = "https://github.com/JustusAdam/rustc_plugin", rev = "aa83f5740fa7eb5b8e3e1ee417b29536e87cc864" }
+"rustc_plugin:0.7.4-nightly-2023-08-25" = { git = "https://github.com/JustusAdam/rustc_plugin", rev = "d4fefb5c0344cdf4812b4877d5b03cb19a2c4672" }

--- a/crates/flowistry_pdg_construction/tests/pdg.rs
+++ b/crates/flowistry_pdg_construction/tests/pdg.rs
@@ -17,7 +17,9 @@ use rustc_middle::{
     mir::{Terminator, TerminatorKind},
     ty::TyCtxt,
 };
-use rustc_utils::{mir::borrowck_facts, source_map::find_bodies::find_bodies};
+use rustc_utils::{
+    mir::borrowck_facts, source_map::find_bodies::find_bodies, test_utils::CompileResult,
+};
 
 fn get_main(tcx: TyCtxt<'_>) -> LocalDefId {
     find_bodies(tcx)
@@ -36,7 +38,7 @@ fn pdg(
     tests: impl for<'tcx> FnOnce(TyCtxt<'tcx>, DepGraph<'tcx>) + Send,
 ) {
     let _ = env_logger::try_init();
-    rustc_utils::test_utils::compile(input, move |tcx| {
+    rustc_utils::test_utils::CompileBuilder::new(input).compile(move |CompileResult { tcx }| {
         let def_id = get_main(tcx);
         let params = configure(tcx, PdgParams::new(tcx, def_id).unwrap());
         let pdg = flowistry_pdg_construction::compute_pdg(params);

--- a/crates/paralegal-flow/Cargo.toml
+++ b/crates/paralegal-flow/Cargo.toml
@@ -59,6 +59,7 @@ chrono = "0.4"
 
 [dev-dependencies]
 paralegal-flow = { path = ".", features = ["test"] }
+rustc_utils = { workspace = true, features = ["test"] }
 
 [[bin]]
 name = "cargo-paralegal-flow"

--- a/crates/paralegal-flow/Cargo.toml
+++ b/crates/paralegal-flow/Cargo.toml
@@ -9,7 +9,7 @@ description = "Extractor for precise semantic PDGs from rust code."
 rustc_private = true
 
 [features]
-test = []
+test = ["rustc_utils/test"]
 
 [dependencies]
 paralegal-spdg = { path = "../paralegal-spdg", features = ["rustc"] }
@@ -59,7 +59,6 @@ chrono = "0.4"
 
 [dev-dependencies]
 paralegal-flow = { path = ".", features = ["test"] }
-rustc_utils = { workspace = true, features = ["test"] }
 
 [[bin]]
 name = "cargo-paralegal-flow"

--- a/crates/paralegal-flow/src/args.rs
+++ b/crates/paralegal-flow/src/args.rs
@@ -385,10 +385,9 @@ impl Args {
             .without_timestamps()
             .init()
             .is_ok()
+            && matches!(*self.direct_debug(), LogLevelConfig::Targeted(..))
         {
-            if matches!(*self.direct_debug(), LogLevelConfig::Targeted(..)) {
-                log::set_max_level(log::LevelFilter::Warn);
-            }
+            log::set_max_level(log::LevelFilter::Warn);
         }
     }
 }

--- a/crates/paralegal-flow/src/args.rs
+++ b/crates/paralegal-flow/src/args.rs
@@ -374,6 +374,23 @@ impl Args {
     pub fn attach_to_debugger(&self) -> Option<Debugger> {
         self.attach_to_debugger
     }
+
+    pub fn setup_logging(&self) {
+        let lvl = self.verbosity();
+        // //let lvl = log::LevelFilter::Debug;
+        if simple_logger::SimpleLogger::new()
+            .with_level(lvl)
+            .with_module_level("flowistry", lvl)
+            .with_module_level("rustc_utils", log::LevelFilter::Error)
+            .without_timestamps()
+            .init()
+            .is_ok()
+        {
+            if matches!(*self.direct_debug(), LogLevelConfig::Targeted(..)) {
+                log::set_max_level(log::LevelFilter::Warn);
+            }
+        }
+    }
 }
 
 #[derive(serde::Serialize, serde::Deserialize, clap::Args, Default)]

--- a/crates/paralegal-flow/src/lib.rs
+++ b/crates/paralegal-flow/src/lib.rs
@@ -350,17 +350,8 @@ impl rustc_plugin::RustcPlugin for DfppPlugin {
             return rustc_driver::RunCompiler::new(&compiler_args, &mut NoopCallbacks {}).run();
         }
 
-        let lvl = plugin_args.verbosity();
-        // //let lvl = log::LevelFilter::Debug;
-        simple_logger::SimpleLogger::new()
-            .with_level(lvl)
-            //.with_module_level("flowistry", lvl)
-            .with_module_level("rustc_utils", log::LevelFilter::Error)
-            .init()
-            .unwrap();
-        if matches!(*plugin_args.direct_debug(), LogLevelConfig::Targeted(..)) {
-            log::set_max_level(log::LevelFilter::Warn);
-        }
+        plugin_args.setup_logging();
+
         let opts = Box::leak(Box::new(plugin_args));
 
         compiler_args.extend([


### PR DESCRIPTION
## What Changed?

Adds the `InlineTestBuilder` which can produce a `PreFrg` compilation result from a string of source code. Integrates with the existing unit test infrastructure.

## Why Does It Need To?

This allows to define test cases without needing external files (as used by the current `define_test!` template) or temporary directories (as used by the `Test` integration test framework) and more importantly the source code for the test inputs is compiled as-needed, which means e.g. tracing output is only reported for the selected test case, and that when test cases are filtered the tests run faster.

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [x] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [x] Documentation in Notion has been updated
- [ ] Tests for new behaviors are provided
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.