### PR TITLE
Migrate auxiliary changes from cross crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,12 +1112,12 @@ name = "rustc_plugin"
 version = "0.7.4-nightly-2023-08-25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1348edfa020dbe4807a4d99272332dadcbbedff6b587accb95faefe20d2c7129"
-replace = "rustc_plugin 0.7.4-nightly-2023-08-25 (git+https://github.com/JustusAdam/rustc_plugin?rev=21fe55d2ac216c4d4d380ec38c1e93163b1f230c)"
+replace = "rustc_plugin 0.7.4-nightly-2023-08-25 (git+https://github.com/JustusAdam/rustc_plugin?rev=20056f4173f111bb4ceaab60499aab1fd1ae0b6a)"
 
 [[package]]
 name = "rustc_plugin"
 version = "0.7.4-nightly-2023-08-25"
-source = "git+https://github.com/JustusAdam/rustc_plugin?rev=21fe55d2ac216c4d4d380ec38c1e93163b1f230c#21fe55d2ac216c4d4d380ec38c1e93163b1f230c"
+source = "git+https://github.com/JustusAdam/rustc_plugin?rev=20056f4173f111bb4ceaab60499aab1fd1ae0b6a#20056f4173f111bb4ceaab60499aab1fd1ae0b6a"
 dependencies = [
  "cargo_metadata",
  "log",
@@ -1138,12 +1138,12 @@ name = "rustc_utils"
 version = "0.7.4-nightly-2023-08-25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09428c7086894369685cca54a516acc0f0ab6d0e5a628c094ba83bfddaf1aedf"
-replace = "rustc_utils 0.7.4-nightly-2023-08-25 (git+https://github.com/JustusAdam/rustc_plugin?rev=21fe55d2ac216c4d4d380ec38c1e93163b1f230c)"
+replace = "rustc_utils 0.7.4-nightly-2023-08-25 (git+https://github.com/JustusAdam/rustc_plugin?rev=20056f4173f111bb4ceaab60499aab1fd1ae0b6a)"
 
 [[package]]
 name = "rustc_utils"
 version = "0.7.4-nightly-2023-08-25"
-source = "git+https://github.com/JustusAdam/rustc_plugin?rev=21fe55d2ac216c4d4d380ec38c1e93163b1f230c#21fe55d2ac216c4d4d380ec38c1e93163b1f230c"
+source = "git+https://github.com/JustusAdam/rustc_plugin?rev=20056f4173f111bb4ceaab60499aab1fd1ae0b6a#20056f4173f111bb4ceaab60499aab1fd1ae0b6a"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,12 +1112,12 @@ name = "rustc_plugin"
 version = "0.7.4-nightly-2023-08-25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1348edfa020dbe4807a4d99272332dadcbbedff6b587accb95faefe20d2c7129"
-replace = "rustc_plugin 0.7.4-nightly-2023-08-25 (git+https://github.com/JustusAdam/rustc_plugin?rev=20056f4173f111bb4ceaab60499aab1fd1ae0b6a)"
+replace = "rustc_plugin 0.7.4-nightly-2023-08-25 (git+https://github.com/JustusAdam/rustc_plugin?rev=6cc378d254e0c4fdfdbec975f82302173bfa0586)"
 
 [[package]]
 name = "rustc_plugin"
 version = "0.7.4-nightly-2023-08-25"
-source = "git+https://github.com/JustusAdam/rustc_plugin?rev=20056f4173f111bb4ceaab60499aab1fd1ae0b6a#20056f4173f111bb4ceaab60499aab1fd1ae0b6a"
+source = "git+https://github.com/JustusAdam/rustc_plugin?rev=6cc378d254e0c4fdfdbec975f82302173bfa0586#6cc378d254e0c4fdfdbec975f82302173bfa0586"
 dependencies = [
  "cargo_metadata",
  "log",
@@ -1138,12 +1138,12 @@ name = "rustc_utils"
 version = "0.7.4-nightly-2023-08-25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09428c7086894369685cca54a516acc0f0ab6d0e5a628c094ba83bfddaf1aedf"
-replace = "rustc_utils 0.7.4-nightly-2023-08-25 (git+https://github.com/JustusAdam/rustc_plugin?rev=20056f4173f111bb4ceaab60499aab1fd1ae0b6a)"
+replace = "rustc_utils 0.7.4-nightly-2023-08-25 (git+https://github.com/JustusAdam/rustc_plugin?rev=6cc378d254e0c4fdfdbec975f82302173bfa0586)"
 
 [[package]]
 name = "rustc_utils"
 version = "0.7.4-nightly-2023-08-25"
-source = "git+https://github.com/JustusAdam/rustc_plugin?rev=20056f4173f111bb4ceaab60499aab1fd1ae0b6a#20056f4173f111bb4ceaab60499aab1fd1ae0b6a"
+source = "git+https://github.com/JustusAdam/rustc_plugin?rev=6cc378d254e0c4fdfdbec975f82302173bfa0586#6cc378d254e0c4fdfdbec975f82302173bfa0586"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,12 +1112,12 @@ name = "rustc_plugin"
 version = "0.7.4-nightly-2023-08-25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1348edfa020dbe4807a4d99272332dadcbbedff6b587accb95faefe20d2c7129"
-replace = "rustc_plugin 0.7.4-nightly-2023-08-25 (git+https://github.com/JustusAdam/rustc_plugin?rev=dd382b79fc12ee86bc774c290a00bda32a0d54db)"
+replace = "rustc_plugin 0.7.4-nightly-2023-08-25 (git+https://github.com/JustusAdam/rustc_plugin?rev=21fe55d2ac216c4d4d380ec38c1e93163b1f230c)"
 
 [[package]]
 name = "rustc_plugin"
 version = "0.7.4-nightly-2023-08-25"
-source = "git+https://github.com/JustusAdam/rustc_plugin?rev=dd382b79fc12ee86bc774c290a00bda32a0d54db#dd382b79fc12ee86bc774c290a00bda32a0d54db"
+source = "git+https://github.com/JustusAdam/rustc_plugin?rev=21fe55d2ac216c4d4d380ec38c1e93163b1f230c#21fe55d2ac216c4d4d380ec38c1e93163b1f230c"
 dependencies = [
  "cargo_metadata",
  "log",
@@ -1138,12 +1138,12 @@ name = "rustc_utils"
 version = "0.7.4-nightly-2023-08-25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09428c7086894369685cca54a516acc0f0ab6d0e5a628c094ba83bfddaf1aedf"
-replace = "rustc_utils 0.7.4-nightly-2023-08-25 (git+https://github.com/JustusAdam/rustc_plugin?rev=dd382b79fc12ee86bc774c290a00bda32a0d54db)"
+replace = "rustc_utils 0.7.4-nightly-2023-08-25 (git+https://github.com/JustusAdam/rustc_plugin?rev=21fe55d2ac216c4d4d380ec38c1e93163b1f230c)"
 
 [[package]]
 name = "rustc_utils"
 version = "0.7.4-nightly-2023-08-25"
-source = "git+https://github.com/JustusAdam/rustc_plugin?rev=dd382b79fc12ee86bc774c290a00bda32a0d54db#dd382b79fc12ee86bc774c290a00bda32a0d54db"
+source = "git+https://github.com/JustusAdam/rustc_plugin?rev=21fe55d2ac216c4d4d380ec38c1e93163b1f230c#21fe55d2ac216c4d4d380ec38c1e93163b1f230c"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,6 +492,8 @@ dependencies = [
  "log",
  "petgraph",
  "rustc_utils 0.7.4-nightly-2023-08-25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "strum",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,12 +1110,12 @@ name = "rustc_plugin"
 version = "0.7.4-nightly-2023-08-25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1348edfa020dbe4807a4d99272332dadcbbedff6b587accb95faefe20d2c7129"
-replace = "rustc_plugin 0.7.4-nightly-2023-08-25 (git+https://github.com/JustusAdam/rustc_plugin?rev=d4fefb5c0344cdf4812b4877d5b03cb19a2c4672)"
+replace = "rustc_plugin 0.7.4-nightly-2023-08-25 (git+https://github.com/JustusAdam/rustc_plugin?rev=dd382b79fc12ee86bc774c290a00bda32a0d54db)"
 
 [[package]]
 name = "rustc_plugin"
 version = "0.7.4-nightly-2023-08-25"
-source = "git+https://github.com/JustusAdam/rustc_plugin?rev=d4fefb5c0344cdf4812b4877d5b03cb19a2c4672#d4fefb5c0344cdf4812b4877d5b03cb19a2c4672"
+source = "git+https://github.com/JustusAdam/rustc_plugin?rev=dd382b79fc12ee86bc774c290a00bda32a0d54db#dd382b79fc12ee86bc774c290a00bda32a0d54db"
 dependencies = [
  "cargo_metadata",
  "log",
@@ -1136,12 +1136,12 @@ name = "rustc_utils"
 version = "0.7.4-nightly-2023-08-25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09428c7086894369685cca54a516acc0f0ab6d0e5a628c094ba83bfddaf1aedf"
-replace = "rustc_utils 0.7.4-nightly-2023-08-25 (git+https://github.com/JustusAdam/rustc_plugin?rev=d4fefb5c0344cdf4812b4877d5b03cb19a2c4672)"
+replace = "rustc_utils 0.7.4-nightly-2023-08-25 (git+https://github.com/JustusAdam/rustc_plugin?rev=dd382b79fc12ee86bc774c290a00bda32a0d54db)"
 
 [[package]]
 name = "rustc_utils"
 version = "0.7.4-nightly-2023-08-25"
-source = "git+https://github.com/JustusAdam/rustc_plugin?rev=d4fefb5c0344cdf4812b4877d5b03cb19a2c4672#d4fefb5c0344cdf4812b4877d5b03cb19a2c4672"
+source = "git+https://github.com/JustusAdam/rustc_plugin?rev=dd382b79fc12ee86bc774c290a00bda32a0d54db#dd382b79fc12ee86bc774c290a00bda32a0d54db"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ debug = true
 [replace."rustc_utils:0.7.4-nightly-2023-08-25"]
 # path = "../rustc_plugin/crates/rustc_utils"
 git = "https://github.com/JustusAdam/rustc_plugin"
-rev = "20056f4173f111bb4ceaab60499aab1fd1ae0b6a"
+rev = "6cc378d254e0c4fdfdbec975f82302173bfa0586"
 
 [replace."rustc_plugin:0.7.4-nightly-2023-08-25"]
 # path = "../rustc_plugin/crates/rustc_plugin"
 git = "https://github.com/JustusAdam/rustc_plugin"
-rev = "20056f4173f111bb4ceaab60499aab1fd1ae0b6a"
+rev = "6cc378d254e0c4fdfdbec975f82302173bfa0586"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ debug = true
 [replace."rustc_utils:0.7.4-nightly-2023-08-25"]
 # path = "../rustc_plugin/crates/rustc_utils"
 git = "https://github.com/JustusAdam/rustc_plugin"
-rev = "21fe55d2ac216c4d4d380ec38c1e93163b1f230c"
+rev = "20056f4173f111bb4ceaab60499aab1fd1ae0b6a"
 
 [replace."rustc_plugin:0.7.4-nightly-2023-08-25"]
 # path = "../rustc_plugin/crates/rustc_plugin"
 git = "https://github.com/JustusAdam/rustc_plugin"
-rev = "21fe55d2ac216c4d4d380ec38c1e93163b1f230c"
+rev = "20056f4173f111bb4ceaab60499aab1fd1ae0b6a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ debug = true
 [replace."rustc_utils:0.7.4-nightly-2023-08-25"]
 # path = "../rustc_plugin/crates/rustc_utils"
 git = "https://github.com/JustusAdam/rustc_plugin"
-rev = "dd382b79fc12ee86bc774c290a00bda32a0d54db"
+rev = "21fe55d2ac216c4d4d380ec38c1e93163b1f230c"
 
 [replace."rustc_plugin:0.7.4-nightly-2023-08-25"]
 # path = "../rustc_plugin/crates/rustc_plugin"
 git = "https://github.com/JustusAdam/rustc_plugin"
-rev = "dd382b79fc12ee86bc774c290a00bda32a0d54db"
+rev = "21fe55d2ac216c4d4d380ec38c1e93163b1f230c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,12 @@ debug = true
 # "rustc_utils:0.7.4-nightly-2023-08-25" = { path = "../rustc_plugin/crates/rustc_utils" }
 # "rustc_plugin:0.7.4-nightly-2023-08-25" = { path = "../rustc_plugin/crates/rustc_plugin" }
 
-"rustc_utils:0.7.4-nightly-2023-08-25" = { git = "https://github.com/JustusAdam/rustc_plugin", rev = "d4fefb5c0344cdf4812b4877d5b03cb19a2c4672" }
-"rustc_plugin:0.7.4-nightly-2023-08-25" = { git = "https://github.com/JustusAdam/rustc_plugin", rev = "d4fefb5c0344cdf4812b4877d5b03cb19a2c4672" }
+[replace."rustc_utils:0.7.4-nightly-2023-08-25"]
+# path = "../rustc_plugin/crates/rustc_utils"
+git = "https://github.com/JustusAdam/rustc_plugin"
+rev = "dd382b79fc12ee86bc774c290a00bda32a0d54db"
+
+[replace."rustc_plugin:0.7.4-nightly-2023-08-25"]
+# path = "../rustc_plugin/crates/rustc_plugin"
+git = "https://github.com/JustusAdam/rustc_plugin"
+rev = "dd382b79fc12ee86bc774c290a00bda32a0d54db"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,6 @@ flowistry = { git = "https://github.com/brownsys/flowistry", rev = "b9210041eb84
 [profile.release]
 debug = true
 
-[replace]
-# "rustc_utils:0.7.4-nightly-2023-08-25" = { path = "../rustc_plugin/crates/rustc_utils" }
-# "rustc_plugin:0.7.4-nightly-2023-08-25" = { path = "../rustc_plugin/crates/rustc_plugin" }
 
 [replace."rustc_utils:0.7.4-nightly-2023-08-25"]
 # path = "../rustc_plugin/crates/rustc_utils"

--- a/crates/flowistry_pdg/src/pdg.rs
+++ b/crates/flowistry_pdg/src/pdg.rs
@@ -76,8 +76,8 @@ impl From<Location> for RichLocation {
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct GlobalLocation {
     /// The function containing the location.
-    #[cfg_attr(feature = "rustc", serde(with = "rustc_proxies::LocalDefId"))]
-    pub function: LocalDefId,
+    #[cfg_attr(feature = "rustc", serde(with = "rustc_proxies::DefId"))]
+    pub function: DefId,
 
     /// The location of an instruction in the function, or the function's start.
     pub location: RichLocation,
@@ -151,6 +151,10 @@ impl CallString {
     pub fn push(self, loc: GlobalLocation) -> Self {
         let string = self.0.iter().copied().chain(Some(loc)).collect();
         CallString::new(string)
+    }
+
+    pub fn push_front(self, loc: GlobalLocation) -> Self {
+        CallString::new([loc].into_iter().chain(self.0.iter().copied()).collect())
     }
 
     pub fn is_at_root(self) -> bool {

--- a/crates/flowistry_pdg/src/pdg.rs
+++ b/crates/flowistry_pdg/src/pdg.rs
@@ -76,8 +76,8 @@ impl From<Location> for RichLocation {
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct GlobalLocation {
     /// The function containing the location.
-    #[cfg_attr(feature = "rustc", serde(with = "rustc_proxies::DefId"))]
-    pub function: DefId,
+    #[cfg_attr(feature = "rustc", serde(with = "rustc_proxies::LocalDefId"))]
+    pub function: LocalDefId,
 
     /// The location of an instruction in the function, or the function's start.
     pub location: RichLocation,

--- a/crates/flowistry_pdg/src/rustc_impls.rs
+++ b/crates/flowistry_pdg/src/rustc_impls.rs
@@ -77,7 +77,7 @@ impl From<DefIndex> for def_id::DefIndex {
 impl fmt::Display for GlobalLocation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         tls::with_opt(|opt_tcx| match opt_tcx {
-            Some(tcx) => match tcx.opt_item_name(self.function) {
+            Some(tcx) => match tcx.opt_item_name(self.function.to_def_id()) {
                 Some(name) => name.fmt(f),
                 None => write!(f, "<closure>"),
             },

--- a/crates/flowistry_pdg/src/rustc_impls.rs
+++ b/crates/flowistry_pdg/src/rustc_impls.rs
@@ -77,7 +77,7 @@ impl From<DefIndex> for def_id::DefIndex {
 impl fmt::Display for GlobalLocation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         tls::with_opt(|opt_tcx| match opt_tcx {
-            Some(tcx) => match tcx.opt_item_name(self.function.to_def_id()) {
+            Some(tcx) => match tcx.opt_item_name(self.function) {
                 Some(name) => name.fmt(f),
                 None => write!(f, "<closure>"),
             },

--- a/crates/flowistry_pdg_construction/Cargo.toml
+++ b/crates/flowistry_pdg_construction/Cargo.toml
@@ -23,6 +23,8 @@ flowistry_pdg = { version = "0.1.0", path = "../flowistry_pdg", features = [
 ] }
 #flowistry = { path = "../../../flowistry/crates/flowistry", default-features = false }
 flowistry = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+strum = { workspace = true }
 
 [dev-dependencies]
 rustc_utils = { workspace = true, features = ["indexical", "test"] }

--- a/crates/flowistry_pdg_construction/src/approximation.rs
+++ b/crates/flowistry_pdg_construction/src/approximation.rs
@@ -62,7 +62,8 @@ impl<'tcx, 'a> LocalAnalysis<'tcx, 'a> {
         };
         let mut operands = IndexVec::new();
         operands.push(op.clone());
-        let TyKind::Adt(adt_id, generics) = destination.ty(&self.mono_body, self.tcx()).ty.kind() else {
+        let TyKind::Adt(adt_id, generics) = destination.ty(&self.mono_body, self.tcx()).ty.kind()
+        else {
             unreachable!()
         };
         assert_eq!(adt_id.did(), lang_items.pin_type().unwrap());

--- a/crates/flowistry_pdg_construction/src/approximation.rs
+++ b/crates/flowistry_pdg_construction/src/approximation.rs
@@ -1,0 +1,75 @@
+use log::trace;
+
+use rustc_abi::VariantIdx;
+
+use rustc_hir::def_id::DefId;
+use rustc_index::IndexVec;
+use rustc_middle::{
+    mir::{visit::Visitor, AggregateKind, Location, Operand, Place, Rvalue},
+    ty::TyKind,
+};
+
+use crate::local_analysis::LocalAnalysis;
+
+pub(crate) type ApproximationHandler<'tcx, 'a> =
+    fn(&LocalAnalysis<'tcx, 'a>, &mut dyn Visitor<'tcx>, &[Operand<'tcx>], Place<'tcx>, Location);
+
+impl<'tcx, 'a> LocalAnalysis<'tcx, 'a> {
+    /// Special case behavior for calls to functions used in desugaring async functions.
+    ///
+    /// Ensures that functions like `Pin::new_unchecked` are not modularly-approximated.
+    pub(crate) fn can_approximate_async_functions(
+        &self,
+        def_id: DefId,
+    ) -> Option<ApproximationHandler<'tcx, 'a>> {
+        let lang_items = self.tcx().lang_items();
+        if Some(def_id) == lang_items.new_unchecked_fn() {
+            Some(Self::approximate_new_unchecked)
+        } else if Some(def_id) == lang_items.into_future_fn()
+            // FIXME: better way to get retrieve this stdlib DefId?
+            || self.tcx().def_path_str(def_id) == "<F as std::future::IntoFuture>::into_future"
+        {
+            Some(Self::approximate_into_future)
+        } else {
+            None
+        }
+    }
+
+    fn approximate_into_future(
+        &self,
+        vis: &mut dyn Visitor<'tcx>,
+        args: &[Operand<'tcx>],
+        destination: Place<'tcx>,
+        location: Location,
+    ) {
+        trace!("Handling into_future as assign for {destination:?}");
+        let [op] = args else {
+            unreachable!();
+        };
+        vis.visit_assign(&destination, &Rvalue::Use(op.clone()), location);
+    }
+
+    fn approximate_new_unchecked(
+        &self,
+        vis: &mut dyn Visitor<'tcx>,
+        args: &[Operand<'tcx>],
+        destination: Place<'tcx>,
+        location: Location,
+    ) {
+        let lang_items = self.tcx().lang_items();
+        let [op] = args else {
+            unreachable!();
+        };
+        let mut operands = IndexVec::new();
+        operands.push(op.clone());
+        let TyKind::Adt(adt_id, generics) = destination.ty(&self.body, self.tcx()).ty.kind() else {
+            unreachable!()
+        };
+        assert_eq!(adt_id.did(), lang_items.pin_type().unwrap());
+        let aggregate_kind =
+            AggregateKind::Adt(adt_id.did(), VariantIdx::from_u32(0), generics, None, None);
+        let rvalue = Rvalue::Aggregate(Box::new(aggregate_kind), operands);
+        trace!("Handling new_unchecked as assign for {destination:?}");
+        vis.visit_assign(&destination, &rvalue, location);
+    }
+}

--- a/crates/flowistry_pdg_construction/src/approximation.rs
+++ b/crates/flowistry_pdg_construction/src/approximation.rs
@@ -62,7 +62,7 @@ impl<'tcx, 'a> LocalAnalysis<'tcx, 'a> {
         };
         let mut operands = IndexVec::new();
         operands.push(op.clone());
-        let TyKind::Adt(adt_id, generics) = destination.ty(&self.body, self.tcx()).ty.kind() else {
+        let TyKind::Adt(adt_id, generics) = destination.ty(&self.mono_body, self.tcx()).ty.kind() else {
             unreachable!()
         };
         assert_eq!(adt_id.did(), lang_items.pin_type().unwrap());

--- a/crates/flowistry_pdg_construction/src/async_support.rs
+++ b/crates/flowistry_pdg_construction/src/async_support.rs
@@ -12,10 +12,11 @@ use rustc_middle::{
     ty::{GenericArgsRef, TyCtxt},
 };
 
-use crate::construct::{CallKind, PartialGraph};
-
-use super::construct::GraphConstructor;
-use super::utils::{self, FnResolution};
+use super::{
+    construct::{CallKind, GraphConstructor},
+    graph::PartialGraph,
+    utils::{self, FnResolution},
+};
 
 /// Stores ids that are needed to construct projections around async functions.
 pub(crate) struct AsyncInfo {

--- a/crates/flowistry_pdg_construction/src/async_support.rs
+++ b/crates/flowistry_pdg_construction/src/async_support.rs
@@ -13,7 +13,6 @@ use rustc_middle::{
 };
 
 use super::{
-    graph::PartialGraph,
     local_analysis::{CallKind, LocalAnalysis},
     utils,
 };

--- a/crates/flowistry_pdg_construction/src/callback.rs
+++ b/crates/flowistry_pdg_construction/src/callback.rs
@@ -1,17 +1,16 @@
 //! CAllbacks to influence graph construction and their supporting types.
 
 use flowistry_pdg::{rustc_portable::Location, CallString};
-
-use crate::FnResolution;
+use rustc_middle::ty::Instance;
 
 pub trait CallChangeCallback<'tcx> {
     fn on_inline(&self, info: CallInfo<'tcx>) -> CallChanges;
 
     fn on_inline_miss(
         &self,
-        _resolution: FnResolution<'tcx>,
+        _resolution: Instance<'tcx>,
         _loc: Location,
-        _under_analysis: FnResolution<'tcx>,
+        _under_analysis: Instance<'tcx>,
         _call_string: Option<CallString>,
         _reason: InlineMissReason,
     ) {
@@ -50,11 +49,11 @@ impl Default for CallChanges {
 /// Information about the function being called.
 pub struct CallInfo<'tcx> {
     /// The potentially-monomorphized resolution of the callee.
-    pub callee: FnResolution<'tcx>,
+    pub callee: Instance<'tcx>,
 
     /// If the callee is an async closure created by an `async fn`, this is the
     /// `async fn` item.
-    pub async_parent: Option<FnResolution<'tcx>>,
+    pub async_parent: Option<Instance<'tcx>>,
 
     /// The call-stack up to the current call site.
     pub call_string: CallString,

--- a/crates/flowistry_pdg_construction/src/calling_convention.rs
+++ b/crates/flowistry_pdg_construction/src/calling_convention.rs
@@ -7,7 +7,7 @@ use rustc_middle::{
     ty::TyCtxt,
 };
 
-use crate::{async_support::AsyncInfo, construct::CallKind, utils};
+use crate::{async_support::AsyncInfo, local_analysis::CallKind, utils};
 
 pub enum CallingConvention<'tcx, 'a> {
     Direct(&'a [Operand<'tcx>]),

--- a/crates/flowistry_pdg_construction/src/construct.rs
+++ b/crates/flowistry_pdg_construction/src/construct.rs
@@ -18,136 +18,164 @@ use rustc_middle::{
         visit::Visitor, AggregateKind, BasicBlock, Body, Location, Operand, Place, PlaceElem,
         Rvalue, Statement, Terminator, TerminatorEdges, TerminatorKind, RETURN_PLACE,
     },
-    ty::{GenericArg, List, ParamEnv, TyCtxt, TyKind},
+    ty::{GeneratorArgsRef, GenericArg, Instance, List, ParamEnv, TyCtxt, TyKind},
 };
 use rustc_mir_dataflow::{self as df};
 use rustc_span::ErrorGuaranteed;
-use rustc_utils::cache::Cache;
+use rustc_ty_utils::instance;
 use rustc_utils::{
+    cache::Cache,
     mir::{borrowck_facts, control_dependencies::ControlDependencies},
     BodyExt, PlaceExt,
 };
 
-use super::async_support::*;
-use super::calling_convention::*;
-use super::graph::{DepEdge, DepGraph, DepNode};
-use super::utils::{self, FnResolution};
 use crate::{
-    graph::{SourceUse, TargetUse},
-    mutation::Time,
-    utils::{is_non_default_trait_method, manufacture_substs_for},
-    InlineMissReason, SkipCall,
-};
-use crate::{
-    mutation::{ModularMutationVisitor, Mutation},
-    try_resolve_function, CallChangeCallback, CallChanges, CallInfo,
+    async_support::*,
+    calling_convention::*,
+    graph::{
+        push_call_string_root, DepEdge, DepGraph, DepNode, PartialGraph, SourceUse, TargetUse,
+    },
+    local_analysis::{CallHandling, InstructionState, LocalAnalysis},
+    mutation::{ModularMutationVisitor, Mutation, Time},
+    try_resolve_function,
+    utils::{self, is_non_default_trait_method, manufacture_substs_for},
+    CallChangeCallback, CallChanges, CallInfo, InlineMissReason, SkipCall,
 };
 
-/// Top-level parameters to PDG construction.
-#[derive(Clone)]
-pub struct PdgParams<'tcx> {
-    tcx: TyCtxt<'tcx>,
-    root: FnResolution<'tcx>,
-    call_change_callback: Option<Rc<dyn CallChangeCallback<'tcx> + 'tcx>>,
-    dump_mir: bool,
+/// A memoizing constructor of PDGs.
+///
+/// Each `(LocalDefId, GenericArgs)` pair is guaranteed to be constructed only
+/// once.
+pub struct MemoPdgConstructor<'tcx> {
+    pub(crate) tcx: TyCtxt<'tcx>,
+    pub(crate) call_change_callback: Option<Rc<dyn CallChangeCallback<'tcx> + 'tcx>>,
+    pub(crate) dump_mir: bool,
+    pub(crate) async_info: Rc<AsyncInfo>,
+    pub(crate) pdg_cache: PdgCache<'tcx>,
 }
 
-impl<'tcx> PdgParams<'tcx> {
-    /// Must provide the [`TyCtxt`] and the [`LocalDefId`] of the function that is the root of the PDG.
-    pub fn new(tcx: TyCtxt<'tcx>, root: LocalDefId) -> Result<Self, ErrorGuaranteed> {
-        let root = try_resolve_function(
+impl<'tcx> MemoPdgConstructor<'tcx> {
+    /// Initialize the constructor, parameterized over an [`ArtifactLoader`] for
+    /// retrieving PDGs of functions from dependencies.
+    pub fn new(tcx: TyCtxt<'tcx>) -> Self {
+        Self {
             tcx,
-            root.to_def_id(),
-            tcx.param_env_reveal_all_normalized(root),
-            manufacture_substs_for(tcx, root)?,
-        );
-        Ok(PdgParams {
-            tcx,
-            root,
             call_change_callback: None,
             dump_mir: false,
-        })
+            async_info: AsyncInfo::make(tcx).expect("Async functions are not defined"),
+            pdg_cache: Default::default(),
+        }
     }
 
-    pub fn with_dump_mir(mut self, dump_mir: bool) -> Self {
+    /// Dump the MIR of any function that is visited.
+    pub fn with_dump_mir(&mut self, dump_mir: bool) -> &mut Self {
         self.dump_mir = dump_mir;
         self
     }
 
-    /// Provide a callback for changing the behavior of how the PDG generator manages function calls.
-    ///
-    /// Currently, this callback can either indicate that a function call should be skipped (i.e., not recursed into),
-    /// or indicate that a set of fake effects should occur at the function call. See [`CallChanges`] for details.
-    ///
-    /// For example, in this code:
-    ///
-    /// ```
-    /// fn incr(x: i32) -> i32 { x + 1 }
-    /// fn main() {
-    ///   let a = 0;
-    ///   let b = incr(a);
-    /// }
-    /// ```
-    ///
-    /// When inspecting the call `incr(a)`, the callback will be called with `f({callee: incr, call_string: [main]})`.
-    /// You could apply a hard limit on call string length like this:
-    ///
-    /// ```
-    /// # #![feature(rustc_private)]
-    /// # extern crate rustc_middle;
-    /// # use flowistry_pdg_construction::{PdgParams, SkipCall, CallChanges, CallChangeCallbackFn};
-    /// # use rustc_middle::ty::TyCtxt;
-    /// # const THRESHOLD: usize = 5;
-    /// # fn f<'tcx>(tcx: TyCtxt<'tcx>, params: PdgParams<'tcx>) -> PdgParams<'tcx> {
-    /// params.with_call_change_callback(CallChangeCallbackFn::new(|info| {
-    ///   let skip = if info.call_string.len() > THRESHOLD {
-    ///     SkipCall::Skip
-    ///   } else {
-    ///     SkipCall::NoSkip
-    ///   };
-    ///   CallChanges::default().with_skip(skip)
-    /// }))
-    /// # }
-    /// ```
-    pub fn with_call_change_callback(self, f: impl CallChangeCallback<'tcx> + 'tcx) -> Self {
-        PdgParams {
-            call_change_callback: Some(Rc::new(f)),
-            ..self
+    /// Register a callback to determine how to deal with function calls seen.
+    /// Overwrites any previously registered callback with no warning.
+    pub fn with_call_change_callback(
+        &mut self,
+        callback: impl CallChangeCallback<'tcx> + 'tcx,
+    ) -> &mut Self {
+        self.call_change_callback.replace(Rc::new(callback));
+        self
+    }
+
+    /// Construct the intermediate PDG for this function. Instantiates any
+    /// generic arguments as `dyn <constraints>`.
+    pub fn construct_root<'a>(
+        &'a self,
+        function: LocalDefId,
+    ) -> Result<&'a PartialGraph<'tcx>, Vec<Error<'tcx>>> {
+        let generics =
+            manufacture_substs_for(self.tcx, function.to_def_id()).map_err(|i| vec![i])?;
+        let resolution = try_resolve_function(
+            self.tcx,
+            function.to_def_id(),
+            self.tcx.param_env_reveal_all_normalized(function),
+            generics,
+        )
+        .ok_or_else(|| {
+            vec![Error::instance_resolution_failed(
+                function.to_def_id(),
+                generics,
+                self.tcx.def_span(function),
+            )]
+        })?;
+        self.construct_for(resolution)
+            .and_then(|f| f.ok_or(vec![Error::Impossible]))
+    }
+
+    pub(crate) fn construct_for<'a>(
+        &'a self,
+        resolution: Instance<'tcx>,
+    ) -> Result<Option<&'a PartialGraph<'tcx>>, Vec<Error<'tcx>>> {
+        let def_id = resolution.def_id();
+        let generics = resolution.args;
+        if let Some(local) = def_id.as_local() {
+            let r = self
+                .pdg_cache
+                .get_maybe_recursive((local, generics), |_| {
+                    let g = LocalAnalysis::new(self, resolution)
+                        .map_err(|e| vec![e])?
+                        .construct_partial()?;
+                    trace!(
+                        "Computed new for {} {generics:?}",
+                        self.tcx.def_path_str(local)
+                    );
+                    g.check_invariants();
+                    Ok(g)
+                })
+                .map(Result::as_ref)
+                .transpose()
+                .map_err(Clone::clone)?;
+            if let Some(g) = r {
+                trace!(
+                    "Found pdg for {} with {:?}",
+                    self.tcx.def_path_str(local),
+                    g.generics
+                )
+            };
+            Ok(r)
+        } else {
+            self.loader.load(def_id)
         }
     }
-}
 
-#[derive(PartialEq, Eq, Default, Clone, Debug)]
-pub struct InstructionState<'tcx> {
-    last_mutation: FxHashMap<Place<'tcx>, FxHashSet<RichLocation>>,
-}
+    /// Has a PDG been constructed for this instance before?
+    pub fn is_in_cache(&self, resolution: Instance<'tcx>) -> bool {
+        if let Some(local) = resolution.def_id().as_local() {
+            self.pdg_cache.is_in_cache(&(local, resolution.args))
+        } else {
+            matches!(self.loader.load(resolution.def_id()), Ok(Some(_)))
+        }
+    }
 
-impl<C> DebugWithContext<C> for InstructionState<'_> {}
-
-impl<'tcx> df::JoinSemiLattice for InstructionState<'tcx> {
-    fn join(&mut self, other: &Self) -> bool {
-        utils::hashmap_join(
-            &mut self.last_mutation,
-            &other.last_mutation,
-            utils::hashset_join,
-        )
+    /// Construct a final PDG for this function. Same as
+    /// [`Self::construct_root`] this instantiates all generics as `dyn`.
+    pub fn construct_graph(
+        &self,
+        function: LocalDefId,
+    ) -> Result<DepGraph<'tcx>, Vec<Error<'tcx>>> {
+        let _args = manufacture_substs_for(self.tcx, function.to_def_id())
+            .map_err(|_| anyhow!("rustc error"));
+        let g = self.construct_root(function)?.to_petgraph();
+        Ok(g)
     }
 }
 
-#[derive(Default, Debug)]
-pub struct PartialGraph<'tcx> {
-    nodes: FxHashSet<DepNode<'tcx>>,
-    edges: FxHashSet<(DepNode<'tcx>, DepNode<'tcx>, DepEdge)>,
-}
+type LocalAnalysisResults<'tcx, 'mir> = Results<'tcx, LocalAnalysis<'tcx, 'mir>>;
 
-impl<'mir, 'tcx> ResultsVisitor<'mir, 'tcx, Results<'tcx, DfAnalysis<'mir, 'tcx>>>
+impl<'mir, 'tcx> ResultsVisitor<'mir, 'tcx, LocalAnalysisResults<'tcx, 'mir>>
     for PartialGraph<'tcx>
 {
-    type FlowState = <DfAnalysis<'mir, 'tcx> as AnalysisDomain<'tcx>>::Domain;
+    type FlowState = <LocalAnalysis<'tcx, 'mir> as AnalysisDomain<'tcx>>::Domain;
 
     fn visit_statement_before_primary_effect(
         &mut self,
-        results: &Results<'tcx, DfAnalysis<'mir, 'tcx>>,
+        results: &LocalAnalysisResults<'tcx, 'mir>,
         state: &Self::FlowState,
         statement: &'mir rustc_middle::mir::Statement<'tcx>,
         location: Location,
@@ -175,119 +203,14 @@ impl<'mir, 'tcx> ResultsVisitor<'mir, 'tcx, Results<'tcx, DfAnalysis<'mir, 'tcx>
     /// call site.
     fn visit_terminator_before_primary_effect(
         &mut self,
-        results: &Results<'tcx, DfAnalysis<'mir, 'tcx>>,
+        results: &LocalAnalysisResults<'tcx, 'mir>,
         state: &Self::FlowState,
         terminator: &'mir rustc_middle::mir::Terminator<'tcx>,
         location: Location,
     ) {
-        let mut handle_as_inline = || {
-            let TerminatorKind::Call {
-                func,
-                args,
-                destination,
-                ..
-            } = &terminator.kind
-            else {
-                return None;
-            };
-            let constructor = results.analysis.0;
-
-            let (child_constructor, calling_convention) =
-                match constructor.determine_call_handling(location, func, args)? {
-                    CallHandling::Ready(one, two) => (one, two),
-                    CallHandling::ApproxAsyncFn => {
-                        // Register a synthetic assignment of `future = (arg0, arg1, ...)`.
-                        let rvalue = Rvalue::Aggregate(
-                            Box::new(AggregateKind::Tuple),
-                            IndexVec::from_iter(args.iter().cloned()),
-                        );
-                        self.modular_mutation_visitor(results, state).visit_assign(
-                            destination,
-                            &rvalue,
-                            location,
-                        );
-                        return Some(());
-                    }
-                    CallHandling::ApproxAsyncSM(how) => {
-                        how(
-                            constructor,
-                            &mut self.modular_mutation_visitor(results, state),
-                            args,
-                            *destination,
-                            location,
-                        );
-                        return Some(());
-                    }
-                };
-
-            let child_graph = child_constructor.construct_partial_cached();
-
-            let parentable_srcs =
-                child_graph.parentable_srcs(child_constructor.def_id, &child_constructor.body);
-            let parentable_dsts =
-                child_graph.parentable_dsts(child_constructor.def_id, &child_constructor.body);
-
-            // For each source node CHILD that is parentable to PLACE,
-            // add an edge from PLACE -> CHILD.
-            trace!("PARENT -> CHILD EDGES:");
-            for (child_src, _kind) in parentable_srcs {
-                if let Some(parent_place) = calling_convention.translate_to_parent(
-                    child_src.place,
-                    &constructor.async_info,
-                    constructor.tcx,
-                    &constructor.body,
-                    constructor.def_id.to_def_id(),
-                    *destination,
-                ) {
-                    self.register_mutation(
-                        results,
-                        state,
-                        Inputs::Unresolved {
-                            places: vec![(parent_place, None)],
-                        },
-                        Either::Right(child_src),
-                        location,
-                        TargetUse::Assign,
-                    );
-                }
-            }
-
-            // For each destination node CHILD that is parentable to PLACE,
-            // add an edge from CHILD -> PLACE.
-            //
-            // PRECISION TODO: for a given child place, we only want to connect
-            // the *last* nodes in the child function to the parent, not *all* of them.
-            trace!("CHILD -> PARENT EDGES:");
-            for (child_dst, kind) in parentable_dsts {
-                if let Some(parent_place) = calling_convention.translate_to_parent(
-                    child_dst.place,
-                    &constructor.async_info,
-                    constructor.tcx,
-                    &constructor.body,
-                    constructor.def_id.to_def_id(),
-                    *destination,
-                ) {
-                    self.register_mutation(
-                        results,
-                        state,
-                        Inputs::Resolved {
-                            node: child_dst,
-                            node_use: SourceUse::Operand,
-                        },
-                        Either::Left(parent_place),
-                        location,
-                        kind.map_or(TargetUse::Return, TargetUse::MutArg),
-                    );
-                }
-            }
-            self.nodes.extend(&child_graph.nodes);
-            self.edges.extend(&child_graph.edges);
-            Some(())
-        };
-
         if let TerminatorKind::SwitchInt { discr, .. } = &terminator.kind {
             if let Some(place) = discr.place() {
-                self.register_mutation(
+                self.inner.register_mutation(
                     results,
                     state,
                     Inputs::Unresolved {
@@ -301,41 +224,52 @@ impl<'mir, 'tcx> ResultsVisitor<'mir, 'tcx, Results<'tcx, DfAnalysis<'mir, 'tcx>
             return;
         }
 
-        if handle_as_inline().is_none() {
-            trace!("Handling terminator {:?} as not inlined", terminator.kind);
-            let mut arg_vis = ModularMutationVisitor::new(
-                &results.analysis.0.place_info,
-                move |location, mutation| {
-                    self.register_mutation(
-                        results,
-                        state,
-                        Inputs::Unresolved {
-                            places: mutation.inputs,
-                        },
-                        Either::Left(mutation.mutated),
-                        location,
-                        mutation.mutation_reason,
-                    )
-                },
-            );
-            arg_vis.set_time(Time::Before);
-            arg_vis.visit_terminator(terminator, location);
+        match self
+            .inner
+            .handle_as_inline(results, state, terminator, location)
+        {
+            Ok(false) => (),
+            Ok(true) => return,
+            Err(e) => self.errors.extend(e),
         }
+        trace!("Handling terminator {:?} as not inlined", terminator.kind);
+        let mut arg_vis = ModularMutationVisitor::new(
+            &results.analysis.inner.place_info,
+            move |location, mutation| {
+                self.inner.register_mutation(
+                    results,
+                    state,
+                    Inputs::Unresolved {
+                        places: mutation.inputs,
+                    },
+                    Either::Left(mutation.mutated),
+                    location,
+                    mutation.mutation_reason,
+                )
+            },
+        );
+        arg_vis.set_time(Time::Before);
+        arg_vis.visit_terminator(terminator, location);
     }
 
     fn visit_terminator_after_primary_effect(
         &mut self,
-        results: &Results<'tcx, DfAnalysis<'mir, 'tcx>>,
+        results: &LocalAnalysisResults<'tcx, 'mir>,
         state: &Self::FlowState,
         terminator: &'mir rustc_middle::mir::Terminator<'tcx>,
         location: Location,
     ) {
         if let TerminatorKind::Call { func, args, .. } = &terminator.kind {
-            let constructor = results.analysis.0;
+            let constructor = results.analysis.inner;
 
             if matches!(
-                constructor.determine_call_handling(location, func, args),
-                Some(CallHandling::Ready(_, _))
+                constructor.determine_call_handling(
+                    location,
+                    func,
+                    args,
+                    terminator.source_info.span
+                ),
+                Ok(Some(CallHandling::Ready { .. }))
             ) {
                 return;
             }
@@ -343,9 +277,9 @@ impl<'mir, 'tcx> ResultsVisitor<'mir, 'tcx, Results<'tcx, DfAnalysis<'mir, 'tcx>
 
         trace!("Handling terminator {:?} as not inlined", terminator.kind);
         let mut arg_vis = ModularMutationVisitor::new(
-            &results.analysis.0.place_info,
+            &results.analysis.inner.place_info,
             move |location, mutation| {
-                self.register_mutation(
+                self.inner.register_mutation(
                     results,
                     state,
                     Inputs::Unresolved {
@@ -361,6 +295,158 @@ impl<'mir, 'tcx> ResultsVisitor<'mir, 'tcx, Results<'tcx, DfAnalysis<'mir, 'tcx>
         arg_vis.visit_terminator(terminator, location);
     }
 }
+
+impl<'tcx> PartialGraph<'tcx> {
+    fn modular_mutation_visitor<'a, 'mir>(
+        &'a mut self,
+        results: &'a LocalAnalysisResults<'tcx, 'mir>,
+        state: &'a InstructionState<'tcx>,
+    ) -> ModularMutationVisitor<'a, 'tcx, impl FnMut(Location, Mutation<'tcx>) + 'a> {
+        ModularMutationVisitor::new(
+            &results.analysis.inner.place_info,
+            move |location, mutation| {
+                self.register_mutation(
+                    results,
+                    state,
+                    Inputs::Unresolved {
+                        places: mutation.inputs,
+                    },
+                    Either::Left(mutation.mutated),
+                    location,
+                    mutation.mutation_reason,
+                )
+            },
+        )
+    }
+
+    /// returns whether we were able to successfully handle this as inline
+    fn handle_as_inline<'a>(
+        &mut self,
+        results: &LocalAnalysisResults<'tcx, 'a>,
+        state: &'a InstructionState<'tcx>,
+        terminator: &Terminator<'tcx>,
+        location: Location,
+    ) -> Option<()> {
+        let TerminatorKind::Call {
+            func,
+            args,
+            destination,
+            ..
+        } = &terminator.kind
+        else {
+            return None;
+        };
+        let constructor = results.analysis.inner;
+        let gloc = GlobalLocation {
+            location: location.into(),
+            function: constructor.def_id.to_def_id(),
+        };
+
+        let Some(handling) = constructor.determine_call_handling(
+            location,
+            func,
+            args,
+            terminator.source_info.span,
+        )?
+        else {
+            return Ok(false);
+        };
+
+        let (child_descriptor, calling_convention) = match handling {
+            CallHandling::Ready {
+                calling_convention,
+                descriptor,
+            } => (descriptor, calling_convention),
+            CallHandling::ApproxAsyncFn => {
+                // Register a synthetic assignment of `future = (arg0, arg1, ...)`.
+                let rvalue = Rvalue::Aggregate(
+                    Box::new(AggregateKind::Tuple),
+                    IndexVec::from_iter(args.iter().cloned()),
+                );
+                self.modular_mutation_visitor(results, state).visit_assign(
+                    destination,
+                    &rvalue,
+                    location,
+                );
+                return Some(());
+            }
+            CallHandling::ApproxAsyncSM(how) => {
+                how(
+                    constructor,
+                    &mut self.modular_mutation_visitor(results, state),
+                    args,
+                    *destination,
+                    location,
+                );
+                return Some(());
+            }
+        };
+
+        let child_graph = push_call_string_root(child_descriptor, gloc);
+
+        trace!("Child graph has generics {:?}", child_descriptor.generics);
+
+        let is_root = |n: CallString| n.len() == 2;
+
+        // For each source node CHILD that is parentable to PLACE,
+        // add an edge from PLACE -> CHILD.
+        trace!("PARENT -> CHILD EDGES:");
+        for (child_src, _kind) in child_graph.parentable_srcs(is_root) {
+            if let Some(parent_place) = calling_convention.translate_to_parent(
+                child_src.place,
+                constructor.async_info(),
+                constructor.tcx(),
+                &constructor.body,
+                constructor.def_id.to_def_id(),
+                *destination,
+            ) {
+                self.register_mutation(
+                    results,
+                    state,
+                    Inputs::Unresolved {
+                        places: vec![(parent_place, None)],
+                    },
+                    Either::Right(child_src),
+                    location,
+                    TargetUse::Assign,
+                );
+            }
+        }
+
+        // For each destination node CHILD that is parentable to PLACE,
+        // add an edge from CHILD -> PLACE.
+        //
+        // PRECISION TODO: for a given child place, we only want to connect
+        // the *last* nodes in the child function to the parent, not *all* of them.
+        trace!("CHILD -> PARENT EDGES:");
+        for (child_dst, kind) in child_graph.parentable_dsts(is_root) {
+            if let Some(parent_place) = calling_convention.translate_to_parent(
+                child_dst.place,
+                constructor.async_info(),
+                constructor.tcx(),
+                &constructor.body,
+                constructor.def_id.to_def_id(),
+                *destination,
+            ) {
+                self.register_mutation(
+                    results,
+                    state,
+                    Inputs::Resolved {
+                        node: child_dst,
+                        node_use: SourceUse::Operand,
+                    },
+                    Either::Left(parent_place),
+                    location,
+                    kind.map_or(TargetUse::Return, TargetUse::MutArg),
+                );
+            }
+        }
+        self.nodes.extend(child_graph.nodes);
+        self.edges.extend(child_graph.edges);
+        Some(())
+    }
+}
+
 fn as_arg<'tcx>(node: &DepNode<'tcx>, def_id: LocalDefId, body: &Body<'tcx>) -> Option<Option<u8>> {
     if node.at.leaf().function != def_id {
         return None;
@@ -375,51 +461,9 @@ fn as_arg<'tcx>(node: &DepNode<'tcx>, def_id: LocalDefId, body: &Body<'tcx>) -> 
 }
 
 impl<'tcx> PartialGraph<'tcx> {
-    fn modular_mutation_visitor<'a>(
-        &'a mut self,
-        results: &'a Results<'tcx, DfAnalysis<'_, 'tcx>>,
-        state: &'a InstructionState<'tcx>,
-    ) -> ModularMutationVisitor<'a, 'tcx, impl FnMut(Location, Mutation<'tcx>) + 'a> {
-        ModularMutationVisitor::new(&results.analysis.0.place_info, move |location, mutation| {
-            self.register_mutation(
-                results,
-                state,
-                Inputs::Unresolved {
-                    places: mutation.inputs,
-                },
-                Either::Left(mutation.mutated),
-                location,
-                mutation.mutation_reason,
-            )
-        })
-    }
-    fn parentable_srcs<'a>(
-        &'a self,
-        def_id: LocalDefId,
-        body: &'a Body<'tcx>,
-    ) -> impl Iterator<Item = (DepNode<'tcx>, Option<u8>)> + 'a {
-        self.edges
-            .iter()
-            .map(|(src, _, _)| *src)
-            .filter_map(move |a| Some((a, as_arg(&a, def_id, body)?)))
-            .filter(|(node, _)| node.at.leaf().location.is_start())
-    }
-
-    fn parentable_dsts<'a>(
-        &'a self,
-        def_id: LocalDefId,
-        body: &'a Body<'tcx>,
-    ) -> impl Iterator<Item = (DepNode<'tcx>, Option<u8>)> + 'a {
-        self.edges
-            .iter()
-            .map(|(_, dst, _)| *dst)
-            .filter_map(move |a| Some((a, as_arg(&a, def_id, body)?)))
-            .filter(|node| node.0.at.leaf().location.is_end())
-    }
-
     fn register_mutation(
         &mut self,
-        results: &Results<'tcx, DfAnalysis<'_, 'tcx>>,
+        results: &LocalAnalysisResults<'tcx, '_>,
         state: &InstructionState<'tcx>,
         inputs: Inputs<'tcx>,
         mutated: Either<Place<'tcx>, DepNode<'tcx>>,
@@ -490,33 +534,7 @@ impl<'tcx> PartialGraph<'tcx> {
     }
 }
 
-pub(crate) struct CallingContext<'tcx> {
-    pub(crate) call_string: CallString,
-    pub(crate) param_env: ParamEnv<'tcx>,
-    pub(crate) call_stack: Vec<DefId>,
-}
-
-type PdgCache<'tcx> = Rc<Cache<CallString, Rc<PartialGraph<'tcx>>>>;
-
-pub struct GraphConstructor<'tcx> {
-    pub(crate) tcx: TyCtxt<'tcx>,
-    pub(crate) params: PdgParams<'tcx>,
-    body_with_facts: &'tcx BodyWithBorrowckFacts<'tcx>,
-    pub(crate) body: Cow<'tcx, Body<'tcx>>,
-    pub(crate) def_id: LocalDefId,
-    place_info: PlaceInfo<'tcx>,
-    control_dependencies: ControlDependencies<BasicBlock>,
-    pub(crate) body_assignments: utils::BodyAssignments,
-    pub(crate) calling_context: Option<CallingContext<'tcx>>,
-    start_loc: FxHashSet<RichLocation>,
-    pub(crate) async_info: Rc<AsyncInfo>,
-    pub(crate) pdg_cache: PdgCache<'tcx>,
-}
-
-fn other_as_arg<'tcx>(place: Place<'tcx>, body: &Body<'tcx>) -> Option<u8> {
-    (body.local_kind(place.local) == rustc_middle::mir::LocalKind::Arg)
-        .then(|| place.local.as_u32() as u8 - 1)
-}
+type PdgCache<'tcx> = Rc<Cache<(LocalDefId, GenericArgsRef<'tcx>), PartialGraph<'tcx>>>;
 
 #[derive(Debug)]
 enum Inputs<'tcx> {
@@ -529,705 +547,9 @@ enum Inputs<'tcx> {
     },
 }
 
-impl<'tcx> GraphConstructor<'tcx> {
-    /// Creates a [`GraphConstructor`] at the root of the PDG.
-    pub fn root(params: PdgParams<'tcx>) -> Self {
-        let tcx = params.tcx;
-        GraphConstructor::new(
-            params,
-            None,
-            AsyncInfo::make(tcx).expect("async functions are not defined"),
-            &PdgCache::default(),
-        )
-    }
-
-    /// Creates [`GraphConstructor`] for a function resolved as `fn_resolution` in a given `calling_context`.
-    pub(crate) fn new(
-        params: PdgParams<'tcx>,
-        calling_context: Option<CallingContext<'tcx>>,
-        async_info: Rc<AsyncInfo>,
-        pdg_cache: &PdgCache<'tcx>,
-    ) -> Self {
-        let tcx = params.tcx;
-        let def_id = params.root.def_id().expect_local();
-        let body_with_facts = borrowck_facts::get_body_with_borrowck_facts(tcx, def_id);
-        let param_env = match &calling_context {
-            Some(cx) => cx.param_env,
-            None => ParamEnv::reveal_all(),
-        };
-        let body = params
-            .root
-            .try_monomorphize(tcx, param_env, &body_with_facts.body);
-
-        if params.dump_mir {
-            use std::io::Write;
-            let path = tcx.def_path_str(def_id) + ".mir";
-            let mut f = std::fs::File::create(path.as_str()).unwrap();
-            write!(f, "{}", body.to_string(tcx).unwrap()).unwrap();
-            debug!("Dumped debug MIR {path}");
-        }
-
-        let place_info = PlaceInfo::build(tcx, def_id.to_def_id(), body_with_facts);
-        let control_dependencies = body.control_dependencies();
-
-        let mut start_loc = FxHashSet::default();
-        start_loc.insert(RichLocation::Start);
-
-        let body_assignments = utils::find_body_assignments(&body);
-        let pdg_cache = Rc::clone(pdg_cache);
-
-        GraphConstructor {
-            tcx,
-            params,
-            body_with_facts,
-            body,
-            place_info,
-            control_dependencies,
-            start_loc,
-            def_id,
-            calling_context,
-            body_assignments,
-            async_info,
-            pdg_cache,
-        }
-    }
-
-    /// Creates a [`GlobalLocation`] at the current function.
-    fn make_global_loc(&self, location: impl Into<RichLocation>) -> GlobalLocation {
-        GlobalLocation {
-            function: self.def_id,
-            location: location.into(),
-        }
-    }
-
-    pub(crate) fn calling_context_for(
-        &self,
-        call_stack_extension: DefId,
-        location: Location,
-    ) -> CallingContext<'tcx> {
-        CallingContext {
-            call_string: self.make_call_string(location),
-            param_env: self.tcx.param_env_reveal_all_normalized(self.def_id),
-            call_stack: match &self.calling_context {
-                Some(cx) => {
-                    let mut cx = cx.call_stack.clone();
-                    cx.push(call_stack_extension);
-                    cx
-                }
-                None => vec![],
-            },
-        }
-    }
-
-    pub(crate) fn pdg_params_for_call(&self, root: FnResolution<'tcx>) -> PdgParams<'tcx> {
-        PdgParams {
-            root,
-            ..self.params.clone()
-        }
-    }
-
-    /// Creates a [`CallString`] with the current function at the root,
-    /// with the rest of the string provided by the [`CallingContext`].
-    fn make_call_string(&self, location: impl Into<RichLocation>) -> CallString {
-        let global_loc = self.make_global_loc(location);
-        match &self.calling_context {
-            Some(cx) => cx.call_string.push(global_loc),
-            None => CallString::single(global_loc),
-        }
-    }
-
-    fn make_dep_node(
-        &self,
-        place: Place<'tcx>,
-        location: impl Into<RichLocation>,
-    ) -> DepNode<'tcx> {
-        DepNode::new(place, self.make_call_string(location), self.tcx, &self.body)
-    }
-
-    /// Returns all pairs of `(src, edge)`` such that the given `location` is control-dependent on `edge`
-    /// with input `src`.
-    fn find_control_inputs(&self, location: Location) -> Vec<(DepNode<'tcx>, DepEdge)> {
-        let mut blocks_seen = HashSet::<BasicBlock>::from_iter(Some(location.block));
-        let mut block_queue = vec![location.block];
-        let mut out = vec![];
-        while let Some(block) = block_queue.pop() {
-            if let Some(ctrl_deps) = self.control_dependencies.dependent_on(block) {
-                for dep in ctrl_deps.iter() {
-                    let ctrl_loc = self.body.terminator_loc(dep);
-                    let Terminator {
-                        kind: TerminatorKind::SwitchInt { discr, .. },
-                        ..
-                    } = self.body.basic_blocks[dep].terminator()
-                    else {
-                        if blocks_seen.insert(dep) {
-                            block_queue.push(dep);
-                        }
-                        continue;
-                    };
-                    let Some(ctrl_place) = discr.place() else {
-                        continue;
-                    };
-                    let at = self.make_call_string(ctrl_loc);
-                    let src = DepNode::new(ctrl_place, at, self.tcx, &self.body);
-                    let edge = DepEdge::control(at, SourceUse::Operand, TargetUse::Assign);
-                    out.push((src, edge));
-                }
-            }
-        }
-        out
-    }
-
-    /// Returns the aliases of `place`. See [`PlaceInfo::aliases`] for details.
-    pub(crate) fn aliases(&self, place: Place<'tcx>) -> impl Iterator<Item = Place<'tcx>> + '_ {
-        // MASSIVE HACK ALERT:
-        // The issue is that monomorphization erases regions, due to how it's implemented in rustc.
-        // However, Flowistry's alias analysis uses regions to figure out aliases.
-        // To workaround this incompatibility, when we receive a monomorphized place, we try to
-        // recompute its type in the context of the original region-containing body as far as possible.
-        //
-        // For example, say _2: (&'0 impl Foo,) in the original body and _2: (&(i32, i32),) in the monomorphized body.
-        // Say we ask for aliases (*(_2.0)).0. Then we will retype ((*_2.0).0).0 and receive back (*_2.0: &'0 impl Foo).
-        // We can ask for the aliases in the context of the original body, receiving e.g. {_1}.
-        // Then we reproject the aliases with the remaining projection, to create {_1.0}.
-        //
-        // This is a massive hack bc it's inefficient and I'm not certain that it's sound.
-        let place_retyped = utils::retype_place(
-            place,
-            self.tcx,
-            &self.body_with_facts.body,
-            self.def_id.to_def_id(),
-        );
-        self.place_info.aliases(place_retyped).iter().map(|alias| {
-            let mut projection = alias.projection.to_vec();
-            projection.extend(&place.projection[place_retyped.projection.len()..]);
-            Place::make(alias.local, &projection, self.tcx)
-        })
-    }
-
-    /// Returns all nodes `src` such that `src` is:
-    /// 1. Part of the value of `input`
-    /// 2. The most-recently modified location for `src`
-    fn find_data_inputs(
-        &self,
-        state: &InstructionState<'tcx>,
-        input: Place<'tcx>,
-    ) -> Vec<DepNode<'tcx>> {
-        // Include all sources of indirection (each reference in the chain) as relevant places.
-        let provenance = input
-            .refs_in_projection(self.place_info.body, self.place_info.tcx)
-            .map(|(place_ref, _)| Place::from_ref(place_ref, self.tcx));
-        let inputs = iter::once(input).chain(provenance);
-
-        inputs
-            // **POINTER-SENSITIVITY:**
-            // If `input` involves indirection via dereferences, then resolve it to the direct places it could point to.
-            .flat_map(|place| self.aliases(place))
-            .flat_map(|alias| {
-                // **FIELD-SENSITIVITY:**
-                // Find all places that have been mutated which conflict with `alias.`
-                let conflicts = state
-                    .last_mutation
-                    .iter()
-                    .map(|(k, locs)| (*k, locs))
-                    .filter(move |(place, _)| {
-                        if place.is_indirect() && place.is_arg(&self.body) {
-                            // HACK: `places_conflict` seems to consider it a bug is `borrow_place`
-                            // includes a dereference, which should only happen if `borrow_place`
-                            // is an argument. So we special case that condition and just compare for local equality.
-                            //
-                            // TODO: this is not field-sensitive!
-                            place.local == alias.local
-                        } else {
-                            let mut place = *place;
-                            if let Some((PlaceElem::Deref, rest)) = place.projection.split_last() {
-                                let mut new_place = place;
-                                new_place.projection = self.tcx.mk_place_elems(rest);
-                                if new_place.ty(self.body.as_ref(), self.tcx).ty.is_box() {
-                                    if new_place.is_indirect() {
-                                        // TODO might be unsound: We assume that if
-                                        // there are other indirections in here,
-                                        // there is an alias that does not have
-                                        // indirections in it.
-                                        return false;
-                                    }
-                                    place = new_place;
-                                }
-                            }
-                            places_conflict(
-                                self.tcx,
-                                &self.body,
-                                place,
-                                alias,
-                                PlaceConflictBias::Overlap,
-                            )
-                        }
-                    });
-
-                // Special case: if the `alias` is an un-mutated argument, then include it as a conflict
-                // coming from the special start location.
-                let alias_last_mut = if alias.is_arg(&self.body) {
-                    Some((alias, &self.start_loc))
-                } else {
-                    None
-                };
-
-                // For each `conflict`` last mutated at the locations `last_mut`:
-                conflicts
-                    .chain(alias_last_mut)
-                    .flat_map(|(conflict, last_mut_locs)| {
-                        // For each last mutated location:
-                        last_mut_locs.iter().map(move |last_mut_loc| {
-                            // Return <CONFLICT> @ <LAST_MUT_LOC> as an input node.
-                            let at = self.make_call_string(*last_mut_loc);
-                            DepNode::new(conflict, at, self.tcx, &self.body)
-                        })
-                    })
-            })
-            .collect()
-    }
-
-    fn find_outputs(
-        &self,
-        _state: &InstructionState<'tcx>,
-        mutated: Place<'tcx>,
-        location: Location,
-    ) -> Vec<(Place<'tcx>, DepNode<'tcx>)> {
-        // **POINTER-SENSITIVITY:**
-        // If `mutated` involves indirection via dereferences, then resolve it to the direct places it could point to.
-        let aliases = self.aliases(mutated);
-
-        // **FIELD-SENSITIVITY:** we do NOT deal with fields on *writes* (in this function),
-        // only on *reads* (in `add_input_to_op`).
-
-        // For each mutated `dst`:
-        aliases
-            .map(|dst| {
-                // Create a destination node for (DST @ CURRENT_LOC).
-                (
-                    dst,
-                    DepNode::new(dst, self.make_call_string(location), self.tcx, &self.body),
-                )
-            })
-            .collect()
-    }
-
-    /// Updates the last-mutated location for `dst` to the given `location`.
-    fn apply_mutation(
-        &self,
-        state: &mut InstructionState<'tcx>,
-        location: Location,
-        mutated: Place<'tcx>,
-    ) {
-        self.find_outputs(state, mutated, location)
-            .into_iter()
-            .for_each(|(dst, _)| {
-                // Create a destination node for (DST @ CURRENT_LOC).
-
-                // Clear all previous mutations.
-                let dst_mutations = state.last_mutation.entry(dst).or_default();
-                dst_mutations.clear();
-
-                // Register that `dst` is mutated at the current location.
-                dst_mutations.insert(RichLocation::Location(location));
-            })
-    }
-
-    /// Resolve a function [`Operand`] to a specific [`DefId`] and generic arguments if possible.
-    pub(crate) fn operand_to_def_id(
-        &self,
-        func: &Operand<'tcx>,
-    ) -> Option<(DefId, &'tcx List<GenericArg<'tcx>>)> {
-        let ty = match func {
-            Operand::Constant(func) => func.literal.ty(),
-            Operand::Copy(place) | Operand::Move(place) => {
-                place.ty(&self.body.local_decls, self.tcx).ty
-            }
-        };
-        let ty = utils::ty_resolve(ty, self.tcx);
-        match ty.kind() {
-            TyKind::FnDef(def_id, generic_args) => Some((*def_id, generic_args)),
-            TyKind::Generator(def_id, generic_args, _) => Some((*def_id, generic_args)),
-            ty => {
-                trace!("Bailing from handle_call because func is literal with type: {ty:?}");
-                None
-            }
-        }
-    }
-
-    fn fmt_fn(&self, def_id: DefId) -> String {
-        self.tcx.def_path_str(def_id)
-    }
-
-    /// Special case behavior for calls to functions used in desugaring async functions.
-    ///
-    /// Ensures that functions like `Pin::new_unchecked` are not modularly-approximated.
-    fn can_approximate_async_functions(&self, def_id: DefId) -> Option<ApproximationHandler<'tcx>> {
-        let lang_items = self.tcx.lang_items();
-        if Some(def_id) == lang_items.new_unchecked_fn() {
-            Some(Self::approximate_new_unchecked)
-        } else if Some(def_id) == lang_items.into_future_fn()
-            // FIXME: better way to get retrieve this stdlib DefId?
-            || self.tcx.def_path_str(def_id) == "<F as std::future::IntoFuture>::into_future"
-        {
-            Some(Self::approximate_into_future)
-        } else {
-            None
-        }
-    }
-
-    fn approximate_into_future(
-        &self,
-        vis: &mut dyn Visitor<'tcx>,
-        args: &[Operand<'tcx>],
-        destination: Place<'tcx>,
-        location: Location,
-    ) {
-        trace!("Handling into_future as assign for {destination:?}");
-        let [op] = args else {
-            unreachable!();
-        };
-        vis.visit_assign(&destination, &Rvalue::Use(op.clone()), location);
-    }
-
-    fn approximate_new_unchecked(
-        &self,
-        vis: &mut dyn Visitor<'tcx>,
-        args: &[Operand<'tcx>],
-        destination: Place<'tcx>,
-        location: Location,
-    ) {
-        let lang_items = self.tcx.lang_items();
-        let [op] = args else {
-            unreachable!();
-        };
-        let mut operands = IndexVec::new();
-        operands.push(op.clone());
-        let TyKind::Adt(adt_id, generics) = destination.ty(self.body.as_ref(), self.tcx).ty.kind()
-        else {
-            unreachable!()
-        };
-        assert_eq!(adt_id.did(), lang_items.pin_type().unwrap());
-        let aggregate_kind =
-            AggregateKind::Adt(adt_id.did(), VariantIdx::from_u32(0), generics, None, None);
-        let rvalue = Rvalue::Aggregate(Box::new(aggregate_kind), operands);
-        trace!("Handling new_unchecked as assign for {destination:?}");
-        vis.visit_assign(&destination, &rvalue, location);
-    }
-
-    fn determine_call_handling<'a>(
-        &self,
-        location: Location,
-        func: &Operand<'tcx>,
-        args: &'a [Operand<'tcx>],
-    ) -> Option<CallHandling<'tcx, 'a>> {
-        let tcx = self.tcx;
-
-        let (called_def_id, generic_args) = self.operand_to_def_id(func)?;
-        trace!("Resolved call to function: {}", self.fmt_fn(called_def_id));
-
-        // Monomorphize the called function with the known generic_args.
-        let param_env = tcx.param_env_reveal_all_normalized(self.def_id);
-        let resolved_fn =
-            utils::try_resolve_function(self.tcx, called_def_id, param_env, generic_args);
-        let resolved_def_id = resolved_fn.def_id();
-        if log_enabled!(Level::Trace) && called_def_id != resolved_def_id {
-            let (called, resolved) = (self.fmt_fn(called_def_id), self.fmt_fn(resolved_def_id));
-            trace!("  `{called}` monomorphized to `{resolved}`",);
-        }
-
-        if is_non_default_trait_method(tcx, resolved_def_id).is_some() {
-            trace!("  bailing because is unresolvable trait method");
-            return None;
-        }
-
-        // Don't inline recursive calls.
-        if let Some(cx) = &self.calling_context {
-            if cx.call_stack.contains(&resolved_def_id) {
-                trace!("  Bailing due to recursive call");
-                return None;
-            }
-        }
-
-        if let Some(handler) = self.can_approximate_async_functions(resolved_def_id) {
-            return Some(CallHandling::ApproxAsyncSM(handler));
-        };
-
-        if !resolved_def_id.is_local() {
-            trace!(
-                "  Bailing because func is non-local: `{}`",
-                tcx.def_path_str(resolved_def_id)
-            );
-            return None;
-        };
-
-        let call_kind = match self.classify_call_kind(called_def_id, resolved_def_id, args) {
-            Ok(cc) => cc,
-            Err(async_err) => {
-                if let Some(cb) = self.params.call_change_callback.as_ref() {
-                    cb.on_inline_miss(
-                        resolved_fn,
-                        location,
-                        self.params.root,
-                        self.calling_context.as_ref().map(|s| s.call_string),
-                        InlineMissReason::Async(async_err),
-                    )
-                }
-                return None;
-            }
-        };
-
-        let calling_convention = CallingConvention::from_call_kind(&call_kind, args);
-
-        trace!(
-            "  Handling call! with kind {}",
-            match &call_kind {
-                CallKind::Direct => "direct",
-                CallKind::Indirect => "indirect",
-                CallKind::AsyncPoll { .. } => "async poll",
-            }
-        );
-
-        // Recursively generate the PDG for the child function.
-        let params = self.pdg_params_for_call(resolved_fn);
-        let calling_context = self.calling_context_for(resolved_def_id, location);
-        let call_string = calling_context.call_string;
-
-        let cache_key = call_string.push(GlobalLocation {
-            function: resolved_fn.def_id().expect_local(),
-            location: RichLocation::Start,
-        });
-
-        let is_cached = self.pdg_cache.is_in_cache(&cache_key);
-
-        let call_changes = self.params.call_change_callback.as_ref().map(|callback| {
-            let info = CallInfo {
-                callee: resolved_fn,
-                call_string,
-                is_cached,
-                async_parent: if let CallKind::AsyncPoll(resolution, _loc, _) = call_kind {
-                    // Special case for async. We ask for skipping not on the closure, but
-                    // on the "async" function that created it. This is needed for
-                    // consistency in skipping. Normally, when "poll" is inlined, mutations
-                    // introduced by the creator of the future are not recorded and instead
-                    // handled here, on the closure. But if the closure is skipped we need
-                    // those mutations to occur. To ensure this we always ask for the
-                    // "CallChanges" on the creator so that both creator and closure have
-                    // the same view of whether they are inlined or "Skip"ped.
-                    Some(resolution)
-                } else {
-                    None
-                },
-            };
-            callback.on_inline(info)
-        });
-
-        // Handle async functions at the time of polling, not when the future is created.
-        if tcx.asyncness(resolved_def_id).is_async() {
-            trace!("  Bailing because func is async");
-
-            // If a skip was requested then "poll" will not be inlined later so we
-            // bail with "None" here and perform the mutations. Otherwise we bail with
-            // "Some", knowing that handling "poll" later will handle the mutations.
-            return (!matches!(
-                &call_changes,
-                Some(CallChanges {
-                    skip: SkipCall::Skip,
-                    ..
-                })
-            ))
-            .then_some(CallHandling::ApproxAsyncFn);
-        }
-
-        if matches!(
-            call_changes,
-            Some(CallChanges {
-                skip: SkipCall::Skip,
-                ..
-            })
-        ) {
-            trace!("  Bailing because user callback said to bail");
-            return None;
-        }
-
-        let child_constructor = GraphConstructor::new(
-            params,
-            Some(calling_context),
-            self.async_info.clone(),
-            &self.pdg_cache,
-        );
-        Some(CallHandling::Ready(child_constructor, calling_convention))
-    }
-
-    /// Attempt to inline a call to a function, returning None if call is not inline-able.
-    fn handle_call(
-        &self,
-        state: &mut InstructionState<'tcx>,
-        location: Location,
-        func: &Operand<'tcx>,
-        args: &[Operand<'tcx>],
-        destination: Place<'tcx>,
-    ) -> Option<()> {
-        // Note: my comments here will use "child" to refer to the callee and
-        // "parent" to refer to the caller, since the words are most visually distinct.
-
-        let preamble = self.determine_call_handling(location, func, args)?;
-
-        let (child_constructor, calling_convention) = match preamble {
-            CallHandling::Ready(child_constructor, calling_convention) => {
-                (child_constructor, calling_convention)
-            }
-            CallHandling::ApproxAsyncFn => {
-                // Register a synthetic assignment of `future = (arg0, arg1, ...)`.
-                let rvalue = Rvalue::Aggregate(
-                    Box::new(AggregateKind::Tuple),
-                    IndexVec::from_iter(args.iter().cloned()),
-                );
-                self.modular_mutation_visitor(state)
-                    .visit_assign(&destination, &rvalue, location);
-                return Some(());
-            }
-            CallHandling::ApproxAsyncSM(handler) => {
-                handler(
-                    self,
-                    &mut self.modular_mutation_visitor(state),
-                    args,
-                    destination,
-                    location,
-                );
-                return Some(());
-            }
-        };
-
-        let child_graph = child_constructor.construct_partial_cached();
-
-        let parentable_dsts =
-            child_graph.parentable_dsts(child_constructor.def_id, &child_constructor.body);
-        let parent_body = &self.body;
-        let translate_to_parent = |child: Place<'tcx>| -> Option<Place<'tcx>> {
-            calling_convention.translate_to_parent(
-                child,
-                &self.async_info,
-                self.tcx,
-                parent_body,
-                self.def_id.to_def_id(),
-                destination,
-            )
-        };
-
-        // For each destination node CHILD that is parentable to PLACE,
-        // add an edge from CHILD -> PLACE.
-        //
-        // PRECISION TODO: for a given child place, we only want to connect
-        // the *last* nodes in the child function to the parent, not *all* of them.
-        trace!("CHILD -> PARENT EDGES:");
-        for (child_dst, _) in parentable_dsts {
-            if let Some(parent_place) = translate_to_parent(child_dst.place) {
-                self.apply_mutation(state, location, parent_place);
-            }
-        }
-        trace!(
-            "  Inlined {}",
-            self.fmt_fn(child_constructor.def_id.to_def_id())
-        );
-
-        Some(())
-    }
-
-    fn modular_mutation_visitor<'a>(
-        &'a self,
-        state: &'a mut InstructionState<'tcx>,
-    ) -> ModularMutationVisitor<'a, 'tcx, impl FnMut(Location, Mutation<'tcx>) + 'a> {
-        ModularMutationVisitor::new(
-            &self.place_info,
-            move |location, mutation: Mutation<'tcx>| {
-                self.apply_mutation(state, location, mutation.mutated)
-            },
-        )
-    }
-
-    fn handle_terminator(
-        &self,
-        terminator: &Terminator<'tcx>,
-        state: &mut InstructionState<'tcx>,
-        location: Location,
-        time: Time,
-    ) {
-        if let TerminatorKind::Call {
-            func,
-            args,
-            destination,
-            ..
-        } = &terminator.kind
-        {
-            if self
-                .handle_call(state, location, func, args, *destination)
-                .is_none()
-            {
-                trace!("Terminator {:?} failed the preamble", terminator.kind);
-                self.terminator_visitor(state, time)
-                    .visit_terminator(terminator, location)
-            }
-        } else {
-            // Fallback: call the visitor
-            self.terminator_visitor(state, time)
-                .visit_terminator(terminator, location)
-        }
-    }
-
-    fn construct_partial_cached(&self) -> Rc<PartialGraph<'tcx>> {
-        let key = self.make_call_string(RichLocation::Start);
-        let pdg = self
-            .pdg_cache
-            .get(key, move |_| Rc::new(self.construct_partial()));
-        Rc::clone(pdg)
-    }
-
-    pub(crate) fn construct_partial(&self) -> PartialGraph<'tcx> {
-        if let Some(g) = self.try_handle_as_async() {
-            return g;
-        }
-
-        let mut analysis = DfAnalysis(self)
-            .into_engine(self.tcx, &self.body)
-            .iterate_to_fixpoint();
-
-        let mut final_state = PartialGraph::default();
-
-        analysis.visit_reachable_with(&self.body, &mut final_state);
-
-        let all_returns = self.body.all_returns().map(|ret| ret.block).collect_vec();
-        let has_return = !all_returns.is_empty();
-        let mut analysis = analysis.into_results_cursor(&self.body);
-        if has_return {
-            for block in all_returns {
-                analysis.seek_to_block_end(block);
-                let return_state = analysis.get();
-                for (place, locations) in &return_state.last_mutation {
-                    let ret_kind = if place.local == RETURN_PLACE {
-                        TargetUse::Return
-                    } else if let Some(num) = other_as_arg(*place, &self.body) {
-                        TargetUse::MutArg(num)
-                    } else {
-                        continue;
-                    };
-                    for location in locations {
-                        let src = self.make_dep_node(*place, *location);
-                        let dst = self.make_dep_node(*place, RichLocation::End);
-                        let edge = DepEdge::data(
-                            self.make_call_string(self.body.terminator_loc(block)),
-                            SourceUse::Operand,
-                            ret_kind,
-                        );
-                        final_state.edges.insert((src, dst, edge));
-                    }
-                }
-            }
-        }
-
-        final_state
-    }
-
-    fn domain_to_petgraph(self, domain: &PartialGraph<'tcx>) -> DepGraph<'tcx> {
+impl<'tcx> PartialGraph<'tcx> {
+    pub fn to_petgraph(&self) -> DepGraph<'tcx> {
+        let domain = self;
         let mut graph: DiGraph<DepNode<'tcx>, DepEdge> = DiGraph::new();
         let mut nodes = FxHashMap::default();
         macro_rules! add_node {
@@ -1249,113 +571,13 @@ impl<'tcx> GraphConstructor<'tcx> {
         DepGraph::new(graph)
     }
 
-    pub fn construct(self) -> DepGraph<'tcx> {
-        let partial = self.construct_partial_cached();
-        self.domain_to_petgraph(&partial)
-    }
-
-    /// Determine the type of call-site.
-    ///
-    /// The error case is if we tried to resolve this as async and failed. We
-    /// know it *is* async but we couldn't determine the information needed to
-    /// analyze the function, therefore we will have to approximate it.
-    fn classify_call_kind<'a>(
-        &'a self,
-        def_id: DefId,
-        resolved_def_id: DefId,
-        original_args: &'a [Operand<'tcx>],
-    ) -> Result<CallKind<'tcx>, String> {
-        match self.try_poll_call_kind(def_id, original_args) {
-            AsyncDeterminationResult::Resolved(r) => Ok(r),
-            AsyncDeterminationResult::NotAsync => Ok(self
-                .try_indirect_call_kind(resolved_def_id)
-                .unwrap_or(CallKind::Direct)),
-            AsyncDeterminationResult::Unresolvable(reason) => Err(reason),
+    fn check_invariants(&self) {
+        let root_function = self.nodes.iter().next().unwrap().at.root().function;
+        for n in &self.nodes {
+            assert_eq!(n.at.root().function, root_function);
         }
-    }
-
-    fn try_indirect_call_kind(&self, def_id: DefId) -> Option<CallKind<'tcx>> {
-        // let lang_items = self.tcx.lang_items();
-        // let my_impl = self.tcx.impl_of_method(def_id)?;
-        // let my_trait = self.tcx.trait_id_of_impl(my_impl)?;
-        // (Some(my_trait) == lang_items.fn_trait()
-        //     || Some(my_trait) == lang_items.fn_mut_trait()
-        //     || Some(my_trait) == lang_items.fn_once_trait())
-        // .then_some(CallKind::Indirect)
-        self.tcx.is_closure(def_id).then_some(CallKind::Indirect)
-    }
-
-    fn terminator_visitor<'a>(
-        &'a self,
-        state: &'a mut InstructionState<'tcx>,
-        time: Time,
-    ) -> ModularMutationVisitor<'a, 'tcx, impl FnMut(Location, Mutation<'tcx>) + 'a> {
-        let mut vis = self.modular_mutation_visitor(state);
-        vis.set_time(time);
-        vis
-    }
-}
-
-pub enum CallKind<'tcx> {
-    /// A standard function call like `f(x)`.
-    Direct,
-    /// A call to a function variable, like `fn foo(f: impl Fn()) { f() }`
-    Indirect,
-    /// A poll to an async function, like `f.await`.
-    AsyncPoll(FnResolution<'tcx>, Location, Place<'tcx>),
-}
-
-type ApproximationHandler<'tcx> =
-    fn(&GraphConstructor<'tcx>, &mut dyn Visitor<'tcx>, &[Operand<'tcx>], Place<'tcx>, Location);
-
-enum CallHandling<'tcx, 'a> {
-    ApproxAsyncFn,
-    Ready(GraphConstructor<'tcx>, CallingConvention<'tcx, 'a>),
-    ApproxAsyncSM(ApproximationHandler<'tcx>),
-}
-
-struct DfAnalysis<'a, 'tcx>(&'a GraphConstructor<'tcx>);
-
-impl<'tcx> df::AnalysisDomain<'tcx> for DfAnalysis<'_, 'tcx> {
-    type Domain = InstructionState<'tcx>;
-
-    const NAME: &'static str = "GraphConstructor";
-
-    fn bottom_value(&self, _body: &Body<'tcx>) -> Self::Domain {
-        InstructionState::default()
-    }
-
-    fn initialize_start_block(&self, _body: &Body<'tcx>, _state: &mut Self::Domain) {}
-}
-
-impl<'tcx> df::Analysis<'tcx> for DfAnalysis<'_, 'tcx> {
-    fn apply_statement_effect(
-        &mut self,
-        state: &mut Self::Domain,
-        statement: &Statement<'tcx>,
-        location: Location,
-    ) {
-        self.0
-            .modular_mutation_visitor(state)
-            .visit_statement(statement, location)
-    }
-
-    fn apply_terminator_effect<'mir>(
-        &mut self,
-        state: &mut Self::Domain,
-        terminator: &'mir Terminator<'tcx>,
-        location: Location,
-    ) -> TerminatorEdges<'mir, 'tcx> {
-        self.0
-            .handle_terminator(terminator, state, location, Time::Unspecified);
-        terminator.edges()
-    }
-
-    fn apply_call_return_effect(
-        &mut self,
-        _state: &mut Self::Domain,
-        _block: BasicBlock,
-        _return_places: rustc_middle::mir::CallReturnPlaces<'_, 'tcx>,
-    ) {
+        for (_, _, e) in &self.edges {
+            assert_eq!(e.at.root().function, root_function);
+        }
     }
 }

--- a/crates/flowistry_pdg_construction/src/construct.rs
+++ b/crates/flowistry_pdg_construction/src/construct.rs
@@ -17,7 +17,7 @@ use rustc_middle::{
 };
 use rustc_mir_dataflow::{self as df};
 
-use rustc_utils::cache::Cache;
+use rustc_utils::{cache::Cache, mir::borrowck_facts::get_body_with_borrowck_facts};
 
 use crate::{
     async_support::*,
@@ -73,7 +73,22 @@ impl<'tcx> MemoPdgConstructor<'tcx> {
 
     /// Construct the intermediate PDG for this function. Instantiates any
     /// generic arguments as `dyn <constraints>`.
+    ///
+    /// Additionally if this is an `async fn` or `#[async_trait]` it will inline
+    /// the closure as though the function were called with `poll`.
     pub fn construct_root<'a>(&'a self, function: LocalDefId) -> &'a PartialGraph<'tcx> {
+        if let Some((generator, _loc, _ty)) = determine_async(
+            self.tcx,
+            function,
+            &get_body_with_borrowck_facts(self.tcx, function).body,
+        ) {
+            // TODO remap arguments
+
+            // Note that this deliberately does not register this result in the
+            // cache for `function`. This is because when this async fn is
+            // called somewhere we don't want to use this "fake inlined" version.
+            return self.construct_root(generator.def_id().expect_local());
+        }
         let generics = manufacture_substs_for(self.tcx, function.to_def_id())
             .map_err(|i| vec![i])
             .unwrap();

--- a/crates/flowistry_pdg_construction/src/graph.rs
+++ b/crates/flowistry_pdg_construction/src/graph.rs
@@ -1,17 +1,29 @@
 //! The representation of the PDG.
 
-use std::{fmt, hash::Hash, path::Path};
+use std::{
+    fmt::{self, Display},
+    hash::Hash,
+    path::Path,
+    rc::Rc,
+};
 
-use flowistry_pdg::CallString;
+use flowistry_pdg::{CallString, GlobalLocation};
 use internment::Intern;
 use petgraph::{dot, graph::DiGraph};
+
+use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hir::def_id::{DefId, DefIndex};
+use rustc_index::IndexVec;
+use rustc_macros::{Decodable, Encodable, TyDecodable, TyEncodable};
 use rustc_middle::{
-    mir::{Body, Place},
-    ty::TyCtxt,
+    mir::{Body, HasLocalDecls, Local, LocalDecl, LocalDecls, Place},
+    ty::{GenericArgsRef, TyCtxt},
 };
 use rustc_utils::PlaceExt;
 
 pub use flowistry_pdg::{SourceUse, TargetUse};
+
+use super::utils::Captures;
 
 /// A node in the program dependency graph.
 ///
@@ -188,4 +200,160 @@ impl<'tcx> DepGraph<'tcx> {
         );
         rustc_utils::mir::body::run_dot(path.as_ref(), graph_dot.into_bytes())
     }
+}
+
+#[derive(Debug, Clone, TyDecodable, TyEncodable)]
+pub struct PartialGraph<'tcx> {
+    pub(crate) nodes: FxHashSet<DepNode<'tcx>>,
+    pub(crate) edges: FxHashSet<(DepNode<'tcx>, DepNode<'tcx>, DepEdge)>,
+    pub(crate) generics: GenericArgsRef<'tcx>,
+    def_id: DefId,
+    arg_count: usize,
+    local_decls: IndexVec<Local, LocalDecl<'tcx>>,
+}
+
+impl<'tcx> HasLocalDecls<'tcx> for PartialGraph<'tcx> {
+    fn local_decls(&self) -> &LocalDecls<'tcx> {
+        &self.local_decls
+    }
+}
+
+impl<'tcx> PartialGraph<'tcx> {
+    pub fn mentioned_call_string<'a>(
+        &'a self,
+    ) -> impl Iterator<Item = CallString> + Captures<'tcx> + 'a {
+        self.nodes
+            .iter()
+            .map(|n| &n.at)
+            .chain(self.edges.iter().map(|e| &e.2.at))
+            .copied()
+    }
+
+    pub fn new(
+        generics: GenericArgsRef<'tcx>,
+        def_id: DefId,
+        arg_count: usize,
+        local_decls: &LocalDecls<'tcx>,
+    ) -> Self {
+        Self {
+            nodes: Default::default(),
+            edges: Default::default(),
+            generics,
+            def_id,
+            arg_count,
+            local_decls: local_decls.to_owned(),
+        }
+    }
+
+    /// Returns the set of source places that the parent can access (write to)
+    ///
+    /// Parameterized by a `is_at_root` function which returns whether a given
+    /// call string refers to a location in the outermost function. This is
+    /// necessary, because consumers of [`PartialGraph`] manipulate the call
+    /// string and as such we cannot assume that `.len() == 1` necessarily refers
+    /// to a root location. (TODO we probably should maintain that invariant)
+    pub(crate) fn parentable_srcs<'a>(
+        &'a self,
+        is_at_root: impl Fn(CallString) -> bool,
+    ) -> FxHashSet<(DepNode<'tcx>, Option<u8>)> {
+        self.edges
+            .iter()
+            .map(|(src, _, _)| *src)
+            .filter(|n| is_at_root(n.at) && n.at.leaf().location.is_start())
+            .filter_map(move |a| Some((a, as_arg(&a, self.def_id, self.arg_count)?)))
+            .collect()
+    }
+
+    /// Returns the set of destination places that the parent can access (read
+    /// from)
+    ///
+    /// Parameterized by a `is_at_root` function which returns whether a given
+    /// call string refers to a location in the outermost function. This is
+    /// necessary, because consumers of [`PartialGraph`] manipulate the call
+    /// string and as such we cannot assume that `.len() == 1` necessarily refers
+    /// to a root location. (TODO we probably should maintain that invariant)
+    pub(crate) fn parentable_dsts<'a>(
+        &'a self,
+        is_at_root: impl Fn(CallString) -> bool,
+    ) -> FxHashSet<(DepNode<'tcx>, Option<u8>)> {
+        self.edges
+            .iter()
+            .map(|(_, dst, _)| *dst)
+            .filter(|n| is_at_root(n.at) && n.at.leaf().location.is_end())
+            .filter_map(move |a| Some((a, as_arg(&a, self.def_id, self.arg_count)?)))
+            .collect()
+    }
+}
+
+fn as_arg(node: &DepNode<'_>, def_id: DefId, arg_count: usize) -> Option<Option<u8>> {
+    if node.at.leaf().function != def_id {
+        return None;
+    }
+    let local = node.place.local.as_usize();
+    if node.place.local == rustc_middle::mir::RETURN_PLACE {
+        Some(None)
+    } else if local > 0 && (local - 1) < arg_count {
+        Some(Some(node.place.local.as_u32() as u8 - 1))
+    } else {
+        None
+    }
+}
+
+impl<'tcx> TransformCallString for PartialGraph<'tcx> {
+    fn transform_call_string(&self, f: impl Fn(CallString) -> CallString) -> Self {
+        let recurse_node = |n: &DepNode<'tcx>| n.transform_call_string(&f);
+        Self {
+            generics: self.generics,
+            nodes: self.nodes.iter().map(recurse_node).collect(),
+            edges: self
+                .edges
+                .iter()
+                .map(|(from, to, e)| {
+                    (
+                        recurse_node(from),
+                        recurse_node(to),
+                        e.transform_call_string(&f),
+                    )
+                })
+                .collect(),
+            def_id: self.def_id,
+            arg_count: self.arg_count,
+            local_decls: self.local_decls.to_owned(),
+        }
+    }
+}
+
+pub(crate) trait TransformCallString {
+    fn transform_call_string(&self, f: impl Fn(CallString) -> CallString) -> Self;
+}
+
+impl TransformCallString for CallString {
+    fn transform_call_string(&self, f: impl Fn(CallString) -> CallString) -> Self {
+        f(*self)
+    }
+}
+
+impl TransformCallString for DepNode<'_> {
+    fn transform_call_string(&self, f: impl Fn(CallString) -> CallString) -> Self {
+        Self {
+            at: f(self.at),
+            ..*self
+        }
+    }
+}
+
+impl TransformCallString for DepEdge {
+    fn transform_call_string(&self, f: impl Fn(CallString) -> CallString) -> Self {
+        Self {
+            at: f(self.at),
+            ..*self
+        }
+    }
+}
+
+pub(crate) fn push_call_string_root<T: TransformCallString>(
+    old: &T,
+    new_root: GlobalLocation,
+) -> T {
+    old.transform_call_string(|c| c.push_front(new_root))
 }

--- a/crates/flowistry_pdg_construction/src/graph.rs
+++ b/crates/flowistry_pdg_construction/src/graph.rs
@@ -1,18 +1,17 @@
 //! The representation of the PDG.
 
 use std::{
-    fmt::{self, Display},
+    fmt::{self},
     hash::Hash,
     path::Path,
-    rc::Rc,
 };
 
 use flowistry_pdg::{CallString, GlobalLocation, RichLocation};
 use internment::Intern;
 use petgraph::{dot, graph::DiGraph};
 
-use rustc_hash::{FxHashMap, FxHashSet};
-use rustc_hir::def_id::{DefId, DefIndex, LocalDefId};
+use rustc_hash::FxHashSet;
+use rustc_hir::def_id::LocalDefId;
 use rustc_index::IndexVec;
 use rustc_middle::{
     mir::{Body, HasLocalDecls, Local, LocalDecl, LocalDecls, Place},

--- a/crates/flowistry_pdg_construction/src/lib.rs
+++ b/crates/flowistry_pdg_construction/src/lib.rs
@@ -13,11 +13,8 @@ extern crate rustc_span;
 extern crate rustc_target;
 extern crate rustc_type_ir;
 
-pub use utils::FnResolution;
-
 use self::graph::DepGraph;
 pub use async_support::{determine_async, is_async_trait_fn, match_async_trait_assign};
-use construct::GraphConstructor;
 pub mod callback;
 pub use crate::construct::MemoPdgConstructor;
 pub use callback::{
@@ -25,6 +22,7 @@ pub use callback::{
 };
 use rustc_middle::ty::{Instance, TyCtxt};
 
+mod approximation;
 mod async_support;
 mod calling_convention;
 mod construct;
@@ -36,9 +34,5 @@ pub mod utils;
 /// Computes a global program dependence graph (PDG) starting from the root function specified by `def_id`.
 pub fn compute_pdg<'tcx>(tcx: TyCtxt<'tcx>, params: Instance<'tcx>) -> DepGraph<'tcx> {
     let constructor = MemoPdgConstructor::new(tcx);
-    constructor
-        .construct_for(params)
-        .unwrap()
-        .unwrap()
-        .to_petgraph()
+    constructor.construct_for(params).unwrap().to_petgraph()
 }

--- a/crates/flowistry_pdg_construction/src/lib.rs
+++ b/crates/flowistry_pdg_construction/src/lib.rs
@@ -33,7 +33,7 @@ mod mutation;
 pub mod utils;
 
 /// Computes a global program dependence graph (PDG) starting from the root function specified by `def_id`.
-pub fn compute_pdg<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> DepGraph<'tcx> {
+pub fn compute_pdg(tcx: TyCtxt<'_>, def_id: LocalDefId) -> DepGraph<'_> {
     let constructor = MemoPdgConstructor::new(tcx);
     constructor.construct_graph(def_id)
 }

--- a/crates/flowistry_pdg_construction/src/lib.rs
+++ b/crates/flowistry_pdg_construction/src/lib.rs
@@ -15,6 +15,7 @@ extern crate rustc_type_ir;
 
 use self::graph::DepGraph;
 pub use async_support::{determine_async, is_async_trait_fn, match_async_trait_assign};
+use rustc_hir::def_id::LocalDefId;
 pub mod callback;
 pub use crate::construct::MemoPdgConstructor;
 pub use callback::{
@@ -32,7 +33,7 @@ mod mutation;
 pub mod utils;
 
 /// Computes a global program dependence graph (PDG) starting from the root function specified by `def_id`.
-pub fn compute_pdg<'tcx>(tcx: TyCtxt<'tcx>, params: Instance<'tcx>) -> DepGraph<'tcx> {
+pub fn compute_pdg<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> DepGraph<'tcx> {
     let constructor = MemoPdgConstructor::new(tcx);
-    constructor.construct_for(params).unwrap().to_petgraph()
+    constructor.construct_graph(def_id)
 }

--- a/crates/flowistry_pdg_construction/src/lib.rs
+++ b/crates/flowistry_pdg_construction/src/lib.rs
@@ -19,21 +19,26 @@ use self::graph::DepGraph;
 pub use async_support::{determine_async, is_async_trait_fn, match_async_trait_assign};
 use construct::GraphConstructor;
 pub mod callback;
+pub use crate::construct::MemoPdgConstructor;
 pub use callback::{
     CallChangeCallback, CallChangeCallbackFn, CallChanges, CallInfo, InlineMissReason, SkipCall,
 };
-pub use construct::PdgParams;
-pub use utils::{is_non_default_trait_method, try_resolve_function};
+use rustc_middle::ty::{Instance, TyCtxt};
 
 mod async_support;
 mod calling_convention;
 mod construct;
 pub mod graph;
+mod local_analysis;
 mod mutation;
-mod utils;
+pub mod utils;
 
 /// Computes a global program dependence graph (PDG) starting from the root function specified by `def_id`.
-pub fn compute_pdg(params: PdgParams<'_>) -> DepGraph<'_> {
-    let constructor = GraphConstructor::root(params);
-    constructor.construct()
+pub fn compute_pdg<'tcx>(tcx: TyCtxt<'tcx>, params: Instance<'tcx>) -> DepGraph<'tcx> {
+    let constructor = MemoPdgConstructor::new(tcx);
+    constructor
+        .construct_for(params)
+        .unwrap()
+        .unwrap()
+        .to_petgraph()
 }

--- a/crates/flowistry_pdg_construction/src/lib.rs
+++ b/crates/flowistry_pdg_construction/src/lib.rs
@@ -21,7 +21,7 @@ pub use crate::construct::MemoPdgConstructor;
 pub use callback::{
     CallChangeCallback, CallChangeCallbackFn, CallChanges, CallInfo, InlineMissReason, SkipCall,
 };
-use rustc_middle::ty::{Instance, TyCtxt};
+use rustc_middle::ty::TyCtxt;
 
 mod approximation;
 mod async_support;

--- a/crates/flowistry_pdg_construction/src/local_analysis.rs
+++ b/crates/flowistry_pdg_construction/src/local_analysis.rs
@@ -1,0 +1,769 @@
+use std::{collections::HashSet, iter, rc::Rc};
+
+use flowistry::mir::placeinfo::PlaceInfo;
+use flowistry_pdg::{CallString, GlobalLocation, RichLocation};
+use itertools::Itertools;
+use log::{debug, log_enabled, trace, Level};
+
+use rustc_borrowck::consumers::{places_conflict, BodyWithBorrowckFacts, PlaceConflictBias};
+use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hir::def_id::{DefId, LocalDefId};
+use rustc_index::IndexVec;
+use rustc_middle::{
+    mir::{
+        visit::Visitor, AggregateKind, BasicBlock, Body, HasLocalDecls, Location, Operand, Place,
+        PlaceElem, Rvalue, Statement, Terminator, TerminatorEdges, TerminatorKind, RETURN_PLACE,
+    },
+    ty::{GenericArg, GenericArgKind, GenericArgsRef, Instance, List, TyCtxt, TyKind},
+};
+use rustc_mir_dataflow::{self as df, fmt::DebugWithContext, Analysis};
+
+use rustc_span::Span;
+use rustc_utils::{
+    mir::{borrowck_facts, control_dependencies::ControlDependencies},
+    BodyExt, PlaceExt,
+};
+
+use crate::{
+    approximation::ApproximationHandler,
+    async_support::*,
+    calling_convention::*,
+    construct::{Error, WithConstructionErrors},
+    graph::{DepEdge, DepNode, PartialGraph, SourceUse, TargetUse},
+    mutation::{ModularMutationVisitor, Mutation, Time},
+    utils::{self, is_async, is_non_default_trait_method, try_monomorphize},
+    CallChangeCallback, CallChanges, CallInfo, MemoPdgConstructor, SkipCall,
+};
+
+#[derive(PartialEq, Eq, Default, Clone, Debug)]
+pub(crate) struct InstructionState<'tcx> {
+    last_mutation: FxHashMap<Place<'tcx>, FxHashSet<RichLocation>>,
+}
+
+impl<C> DebugWithContext<C> for InstructionState<'_> {}
+
+impl<'tcx> df::JoinSemiLattice for InstructionState<'tcx> {
+    fn join(&mut self, other: &Self) -> bool {
+        utils::hashmap_join(
+            &mut self.last_mutation,
+            &other.last_mutation,
+            utils::hashset_join,
+        )
+    }
+}
+
+pub(crate) struct LocalAnalysis<'tcx, 'a> {
+    pub(crate) memo: &'a MemoPdgConstructor<'tcx>,
+    pub(super) root: Instance<'tcx>,
+    body_with_facts: &'tcx BodyWithBorrowckFacts<'tcx>,
+    pub(crate) body: Body<'tcx>,
+    pub(crate) def_id: LocalDefId,
+    pub(crate) place_info: PlaceInfo<'tcx>,
+    control_dependencies: ControlDependencies<BasicBlock>,
+    pub(crate) body_assignments: utils::BodyAssignments,
+    start_loc: FxHashSet<RichLocation>,
+}
+
+impl<'tcx, 'a> LocalAnalysis<'tcx, 'a> {
+    /// Creates [`GraphConstructor`] for a function resolved as `fn_resolution` in a given `calling_context`.
+    pub(crate) fn new(
+        memo: &'a MemoPdgConstructor<'tcx>,
+        root: Instance<'tcx>,
+    ) -> Result<LocalAnalysis<'tcx, 'a>, Error<'tcx>> {
+        let tcx = memo.tcx;
+        let def_id = root.def_id().expect_local();
+        let body_with_facts = borrowck_facts::get_body_with_borrowck_facts(tcx, def_id);
+        let param_env = tcx.param_env_reveal_all_normalized(def_id);
+        // let param_env = match &calling_context {
+        //     Some(cx) => cx.param_env,
+        //     None => ParamEnv::reveal_all(),
+        // };
+        let body = try_monomorphize(
+            root,
+            tcx,
+            param_env,
+            &body_with_facts.body,
+            tcx.def_span(root.def_id()),
+        )?;
+
+        if memo.dump_mir {
+            use std::io::Write;
+            let path = tcx.def_path_str(def_id) + ".mir";
+            let mut f = std::fs::File::create(path.as_str()).unwrap();
+            write!(f, "{}", body.to_string(tcx).unwrap()).unwrap();
+            debug!("Dumped debug MIR {path}");
+        }
+
+        let place_info = PlaceInfo::build(tcx, def_id.to_def_id(), body_with_facts);
+        let control_dependencies = body.control_dependencies();
+
+        let mut start_loc = FxHashSet::default();
+        start_loc.insert(RichLocation::Start);
+
+        let body_assignments = utils::find_body_assignments(&body);
+
+        Ok(LocalAnalysis {
+            memo,
+            root,
+            body_with_facts,
+            body,
+            place_info,
+            control_dependencies,
+            start_loc,
+            def_id,
+            body_assignments,
+        })
+    }
+
+    fn make_dep_node(
+        &self,
+        place: Place<'tcx>,
+        location: impl Into<RichLocation>,
+    ) -> DepNode<'tcx> {
+        DepNode::new(
+            place,
+            self.make_call_string(location),
+            self.tcx(),
+            &self.body,
+        )
+    }
+
+    /// Returns all pairs of `(src, edge)`` such that the given `location` is control-dependent on `edge`
+    /// with input `src`.
+    pub(crate) fn find_control_inputs(&self, location: Location) -> Vec<(DepNode<'tcx>, DepEdge)> {
+        let mut blocks_seen = HashSet::<BasicBlock>::from_iter(Some(location.block));
+        let mut block_queue = vec![location.block];
+        let mut out = vec![];
+        while let Some(block) = block_queue.pop() {
+            if let Some(ctrl_deps) = self.control_dependencies.dependent_on(block) {
+                for dep in ctrl_deps.iter() {
+                    let ctrl_loc = self.body.terminator_loc(dep);
+                    let Terminator {
+                        kind: TerminatorKind::SwitchInt { discr, .. },
+                        ..
+                    } = self.body.basic_blocks[dep].terminator()
+                    else {
+                        if blocks_seen.insert(dep) {
+                            block_queue.push(dep);
+                        }
+                        continue;
+                    };
+                    let Some(ctrl_place) = discr.place() else {
+                        continue;
+                    };
+                    let at = self.make_call_string(ctrl_loc);
+                    let src = self.make_dep_node(ctrl_place, ctrl_loc);
+                    let edge = DepEdge::control(at, SourceUse::Operand, TargetUse::Assign);
+                    out.push((src, edge));
+                }
+            }
+        }
+        out
+    }
+
+    fn call_change_callback(&self) -> Option<&dyn CallChangeCallback<'tcx>> {
+        self.memo.call_change_callback.as_ref().map(Rc::as_ref)
+    }
+
+    pub(crate) fn async_info(&self) -> &AsyncInfo {
+        &self.memo.async_info
+    }
+
+    pub(crate) fn make_call_string(&self, location: impl Into<RichLocation>) -> CallString {
+        CallString::single(GlobalLocation {
+            function: self.root.def_id(),
+            location: location.into(),
+        })
+    }
+
+    /// Returns the aliases of `place`. See [`PlaceInfo::aliases`] for details.
+    pub(crate) fn aliases(&'a self, place: Place<'tcx>) -> impl Iterator<Item = Place<'tcx>> + 'a {
+        // MASSIVE HACK ALERT:
+        // The issue is that monomorphization erases regions, due to how it's implemented in rustc.
+        // However, Flowistry's alias analysis uses regions to figure out aliases.
+        // To workaround this incompatibility, when we receive a monomorphized place, we try to
+        // recompute its type in the context of the original region-containing body as far as possible.
+        //
+        // For example, say _2: (&'0 impl Foo,) in the original body and _2: (&(i32, i32),) in the monomorphized body.
+        // Say we ask for aliases (*(_2.0)).0. Then we will retype ((*_2.0).0).0 and receive back (*_2.0: &'0 impl Foo).
+        // We can ask for the aliases in the context of the original body, receiving e.g. {_1}.
+        // Then we reproject the aliases with the remaining projection, to create {_1.0}.
+        //
+        // This is a massive hack bc it's inefficient and I'm not certain that it's sound.
+        let place_retyped = utils::retype_place(
+            place,
+            self.tcx(),
+            &self.body_with_facts.body,
+            self.def_id.to_def_id(),
+        );
+        self.place_info
+            .aliases(place_retyped)
+            .iter()
+            .map(move |alias| {
+                let mut projection = alias.projection.to_vec();
+                projection.extend(&place.projection[place_retyped.projection.len()..]);
+                let p = Place::make(alias.local, &projection, self.tcx());
+                // let t1 = place.ty(&self.body, self.tcx());
+                // let t2 = p.ty(&self.body, self.tcx());
+                // if !t1.equiv(&t2) {
+                //     let p1_str = format!("{place:?}");
+                //     let p2_str = format!("{p:?}");
+                // let l = p1_str.len().max(p2_str.len());
+                //     panic!("Retyping in {} failed to produce an equivalent type.\n  Src {p1_str:l$} : {t1:?}\n  Dst {p2_str:l$} : {t2:?}", self.tcx().def_path_str(self.def_id))
+                // }
+                p
+            })
+    }
+
+    pub(crate) fn tcx(&self) -> TyCtxt<'tcx> {
+        self.memo.tcx
+    }
+
+    /// Returns all nodes `src` such that `src` is:
+    /// 1. Part of the value of `input`
+    /// 2. The most-recently modified location for `src`
+    pub(crate) fn find_data_inputs(
+        &self,
+        state: &InstructionState<'tcx>,
+        input: Place<'tcx>,
+    ) -> Vec<DepNode<'tcx>> {
+        // Include all sources of indirection (each reference in the chain) as relevant places.
+        let provenance = input
+            .refs_in_projection(&self.body, self.tcx())
+            .map(|(place_ref, _)| Place::from_ref(place_ref, self.tcx()));
+        let inputs = iter::once(input).chain(provenance);
+
+        inputs
+            // **POINTER-SENSITIVITY:**
+            // If `input` involves indirection via dereferences, then resolve it to the direct places it could point to.
+            .flat_map(|place| self.aliases(place))
+            .flat_map(|alias| {
+                // **FIELD-SENSITIVITY:**
+                // Find all places that have been mutated which conflict with `alias.`
+                let conflicts = state
+                    .last_mutation
+                    .iter()
+                    .map(|(k, locs)| (*k, locs))
+                    .filter(move |(place, _)| {
+                        if place.is_indirect() && place.is_arg(&self.body) {
+                            // HACK: `places_conflict` seems to consider it a bug is `borrow_place`
+                            // includes a dereference, which should only happen if `borrow_place`
+                            // is an argument. So we special case that condition and just compare for local equality.
+                            //
+                            // TODO: this is not field-sensitive!
+                            place.local == alias.local
+                        } else {
+                            let mut place = *place;
+                            if let Some((PlaceElem::Deref, rest)) = place.projection.split_last() {
+                                let mut new_place = place;
+                                new_place.projection = self.tcx().mk_place_elems(rest);
+                                if new_place.ty(&self.body, self.tcx()).ty.is_box() {
+                                    if new_place.is_indirect() {
+                                        // TODO might be unsound: We assume that if
+                                        // there are other indirections in here,
+                                        // there is an alias that does not have
+                                        // indirections in it.
+                                        return false;
+                                    }
+                                    place = new_place;
+                                }
+                            }
+                            places_conflict(
+                                self.tcx(),
+                                &self.body,
+                                place,
+                                alias,
+                                PlaceConflictBias::Overlap,
+                            )
+                        }
+                    });
+
+                // Special case: if the `alias` is an un-mutated argument, then include it as a conflict
+                // coming from the special start location.
+                let alias_last_mut = if alias.is_arg(&self.body) {
+                    Some((alias, &self.start_loc))
+                } else {
+                    None
+                };
+
+                // For each `conflict`` last mutated at the locations `last_mut`:
+                conflicts
+                    .chain(alias_last_mut)
+                    .flat_map(|(conflict, last_mut_locs)| {
+                        // For each last mutated location:
+                        last_mut_locs.iter().map(move |last_mut_loc| {
+                            // Return <CONFLICT> @ <LAST_MUT_LOC> as an input node.
+                            self.make_dep_node(conflict, *last_mut_loc)
+                        })
+                    })
+            })
+            .collect()
+    }
+
+    pub(crate) fn find_outputs(
+        &self,
+        mutated: Place<'tcx>,
+        location: Location,
+    ) -> Vec<(Place<'tcx>, DepNode<'tcx>)> {
+        // **POINTER-SENSITIVITY:**
+        // If `mutated` involves indirection via dereferences, then resolve it to the direct places it could point to.
+        let aliases = self.aliases(mutated).collect_vec();
+
+        // **FIELD-SENSITIVITY:** we do NOT deal with fields on *writes* (in this function),
+        // only on *reads* (in `add_input_to_op`).
+
+        // For each mutated `dst`:
+        aliases
+            .iter()
+            .map(|dst| {
+                // Create a destination node for (DST @ CURRENT_LOC).
+                (*dst, self.make_dep_node(*dst, location))
+            })
+            .collect()
+    }
+
+    /// Updates the last-mutated location for `dst` to the given `location`.
+    fn apply_mutation(
+        &self,
+        state: &mut InstructionState<'tcx>,
+        location: Location,
+        mutated: Place<'tcx>,
+    ) {
+        self.find_outputs(mutated, location)
+            .into_iter()
+            .for_each(|(dst, _)| {
+                // Create a destination node for (DST @ CURRENT_LOC).
+
+                // Clear all previous mutations.
+                let dst_mutations = state.last_mutation.entry(dst).or_default();
+                dst_mutations.clear();
+
+                // Register that `dst` is mutated at the current location.
+                dst_mutations.insert(RichLocation::Location(location));
+            })
+    }
+
+    /// Resolve a function [`Operand`] to a specific [`DefId`] and generic arguments if possible.
+    pub(crate) fn operand_to_def_id(
+        &self,
+        func: &Operand<'tcx>,
+    ) -> Option<(DefId, &'tcx List<GenericArg<'tcx>>)> {
+        let ty = func.ty(&self.body, self.tcx());
+        utils::type_as_fn(self.tcx(), ty)
+    }
+
+    fn fmt_fn(&self, def_id: DefId) -> String {
+        self.tcx().def_path_str(def_id)
+    }
+
+    pub(crate) fn determine_call_handling<'b>(
+        &'b self,
+        location: Location,
+        func: &Operand<'tcx>,
+        args: &'b [Operand<'tcx>],
+        span: Span,
+    ) -> Result<Option<CallHandling<'tcx, 'b>>, Vec<Error<'tcx>>> {
+        let tcx = self.tcx();
+
+        trace!(
+            "Considering call at {location:?} in {:?}",
+            self.tcx().def_path_str(self.def_id)
+        );
+
+        let (called_def_id, generic_args) = self
+            .operand_to_def_id(func)
+            .ok_or_else(|| vec![Error::operand_is_not_function_type(func)])?;
+        trace!("Resolved call to function: {}", self.fmt_fn(called_def_id));
+
+        // Monomorphize the called function with the known generic_args.
+        let param_env = tcx.param_env_reveal_all_normalized(self.def_id);
+        let Some(resolved_fn) =
+            utils::try_resolve_function(self.tcx(), called_def_id, param_env, generic_args)
+        else {
+            if let Some(d) = generic_args.iter().find(|arg| matches!(arg.unpack(), GenericArgKind::Type(t) if matches!(t.kind(), TyKind::Dynamic(..)))) {
+                self.tcx().sess.span_warn(self.tcx().def_span(called_def_id), format!("could not resolve instance due to dynamic argument: {d:?}"));
+                return Ok(None);
+            } else {
+                return Err(
+                vec![Error::instance_resolution_failed(
+                    called_def_id,
+                    generic_args,
+                    span
+                )]);
+            }
+        };
+        let resolved_def_id = resolved_fn.def_id();
+        if log_enabled!(Level::Trace) && called_def_id != resolved_def_id {
+            let (called, resolved) = (self.fmt_fn(called_def_id), self.fmt_fn(resolved_def_id));
+            trace!("  `{called}` monomorphized to `{resolved}`",);
+        }
+
+        if is_non_default_trait_method(tcx, resolved_def_id).is_some() {
+            trace!("  bailing because is unresolvable trait method");
+            return Ok(None);
+        }
+
+        if let Some(handler) = self.can_approximate_async_functions(resolved_def_id) {
+            return Ok(Some(CallHandling::ApproxAsyncSM(handler)));
+        };
+
+        let call_kind = match self.classify_call_kind(called_def_id, resolved_def_id, args, span) {
+            Ok(cc) => cc,
+            Err(async_err) => {
+                return Err(vec![async_err]);
+            }
+        };
+
+        let calling_convention = CallingConvention::from_call_kind(&call_kind, args);
+
+        trace!(
+            "  Handling call! with kind {}",
+            match &call_kind {
+                CallKind::Direct => "direct",
+                CallKind::Indirect => "indirect",
+                CallKind::AsyncPoll { .. } => "async poll",
+            }
+        );
+
+        // Recursively generate the PDG for the child function.
+
+        let cache_key = resolved_fn;
+
+        let is_cached = self.memo.is_in_cache(cache_key);
+
+        let call_changes = self.call_change_callback().map(|callback| {
+            let info = CallInfo {
+                callee: resolved_fn,
+                call_string: self.make_call_string(location),
+                is_cached,
+                async_parent: if let CallKind::AsyncPoll(resolution, _loc, _) = call_kind {
+                    // Special case for async. We ask for skipping not on the closure, but
+                    // on the "async" function that created it. This is needed for
+                    // consistency in skipping. Normally, when "poll" is inlined, mutations
+                    // introduced by the creator of the future are not recorded and instead
+                    // handled here, on the closure. But if the closure is skipped we need
+                    // those mutations to occur. To ensure this we always ask for the
+                    // "CallChanges" on the creator so that both creator and closure have
+                    // the same view of whether they are inlined or "Skip"ped.
+                    Some(resolution)
+                } else {
+                    None
+                },
+            };
+            callback.on_inline(info)
+        });
+
+        // Handle async functions at the time of polling, not when the future is created.
+        if is_async(tcx, resolved_def_id) {
+            trace!("  Bailing because func is async");
+
+            // If a skip was requested then "poll" will not be inlined later so we
+            // bail with "None" here and perform the mutations. Otherwise we bail with
+            // "Some", knowing that handling "poll" later will handle the mutations.
+            return Ok((!matches!(
+                &call_changes,
+                Some(CallChanges {
+                    skip: SkipCall::Skip,
+                    ..
+                })
+            ))
+            .then_some(CallHandling::ApproxAsyncFn));
+        }
+
+        if matches!(
+            call_changes,
+            Some(CallChanges {
+                skip: SkipCall::Skip,
+                ..
+            })
+        ) {
+            trace!("  Bailing because user callback said to bail");
+            return Ok(None);
+        }
+        let Some(descriptor) = self.memo.construct_for(cache_key)? else {
+            trace!("  Bailing because cache lookup {cache_key} failed");
+            return Ok(None);
+        };
+        Ok(Some(CallHandling::Ready {
+            descriptor,
+            calling_convention,
+        }))
+    }
+
+    /// Attempt to inline a call to a function.
+    ///
+    /// The return indicates whether we were successfully able to perform the inlining.
+    fn handle_call(
+        &self,
+        state: &mut InstructionState<'tcx>,
+        location: Location,
+        func: &Operand<'tcx>,
+        args: &[Operand<'tcx>],
+        destination: Place<'tcx>,
+        span: Span,
+    ) -> bool {
+        // Note: my comments here will use "child" to refer to the callee and
+        // "parent" to refer to the caller, since the words are most visually distinct.
+
+        let Some(preamble) = self.determine_call_handling(location, func, args, span)? else {
+            return false;
+        };
+
+        trace!("Call handling is {}", preamble.as_ref());
+
+        let (child_constructor, calling_convention) = match preamble {
+            CallHandling::Ready {
+                descriptor,
+                calling_convention,
+            } => (descriptor, calling_convention),
+            CallHandling::ApproxAsyncFn => {
+                // Register a synthetic assignment of `future = (arg0, arg1, ...)`.
+                let rvalue = Rvalue::Aggregate(
+                    Box::new(AggregateKind::Tuple),
+                    IndexVec::from_iter(args.iter().cloned()),
+                );
+                self.modular_mutation_visitor(state)
+                    .visit_assign(&destination, &rvalue, location);
+                return true;
+            }
+            CallHandling::ApproxAsyncSM(handler) => {
+                handler(
+                    self,
+                    &mut self.modular_mutation_visitor(state),
+                    args,
+                    destination,
+                    location,
+                );
+                return true;
+            }
+        };
+
+        let parentable_dsts = child_constructor.parentable_dsts(|n| n.len() == 1);
+        let parent_body = &self.body;
+
+        // For each destination node CHILD that is parentable to PLACE,
+        // add an edge from CHILD -> PLACE.
+        //
+        // PRECISION TODO: for a given child place, we only want to connect
+        // the *last* nodes in the child function to the parent, not *all* of them.
+        trace!("CHILD -> PARENT EDGES:");
+        for (child_dst, _) in parentable_dsts {
+            if let Some(parent_place) = calling_convention.translate_to_parent(
+                child_dst.place,
+                self.async_info(),
+                self.tcx(),
+                parent_body,
+                self.def_id.to_def_id(),
+                destination,
+            ) {
+                self.apply_mutation(state, location, parent_place);
+            }
+        }
+
+        true
+    }
+
+    fn modular_mutation_visitor<'b: 'a>(
+        &'b self,
+        state: &'a mut InstructionState<'tcx>,
+    ) -> ModularMutationVisitor<'b, 'tcx, impl FnMut(Location, Mutation<'tcx>) + 'b> {
+        ModularMutationVisitor::new(
+            &self.place_info,
+            move |location, mutation: Mutation<'tcx>| {
+                self.apply_mutation(state, location, mutation.mutated)
+            },
+        )
+    }
+
+    pub(super) fn generic_args(&self) -> GenericArgsRef<'tcx> {
+        self.root.args
+    }
+
+    pub(crate) fn construct_partial(&'a self) -> Result<PartialGraph<'tcx>, Vec<Error<'tcx>>> {
+        let mut analysis = WithConstructionErrors::new(self)
+            .into_engine(self.tcx(), &self.body)
+            .iterate_to_fixpoint();
+
+        if !analysis.analysis.errors.is_empty() {
+            return Err(analysis.analysis.errors.into_iter().collect());
+        }
+
+        let mut final_state = WithConstructionErrors::new(PartialGraph::new(
+            self.generic_args(),
+            self.def_id.to_def_id(),
+            self.body.arg_count,
+            self.body.local_decls(),
+        ));
+
+        analysis.visit_reachable_with(&self.body, &mut final_state);
+
+        let mut final_state = final_state.into_result()?;
+
+        let all_returns = self.body.all_returns().map(|ret| ret.block).collect_vec();
+        let mut analysis = analysis.into_results_cursor(&self.body);
+        for block in all_returns {
+            analysis.seek_to_block_end(block);
+            let return_state = analysis.get();
+            for (place, locations) in &return_state.last_mutation {
+                let ret_kind = if place.local == RETURN_PLACE {
+                    TargetUse::Return
+                } else if let Some(num) = other_as_arg(*place, &self.body) {
+                    TargetUse::MutArg(num)
+                } else {
+                    continue;
+                };
+                for location in locations {
+                    let src = self.make_dep_node(*place, *location);
+                    let dst = self.make_dep_node(*place, RichLocation::End);
+                    let edge = DepEdge::data(
+                        self.make_call_string(self.body.terminator_loc(block)),
+                        SourceUse::Operand,
+                        ret_kind,
+                    );
+                    final_state.edges.insert((src, dst, edge));
+                }
+            }
+        }
+
+        Ok(final_state)
+    }
+
+    /// Determine the type of call-site.
+    ///
+    /// The error case is if we tried to resolve this as async and failed. We
+    /// know it *is* async but we couldn't determine the information needed to
+    /// analyze the function, therefore we will have to approximate it.
+    fn classify_call_kind<'b>(
+        &'b self,
+        def_id: DefId,
+        resolved_def_id: DefId,
+        original_args: &'b [Operand<'tcx>],
+        span: Span,
+    ) -> Result<CallKind<'tcx>, Error<'tcx>> {
+        match self.try_poll_call_kind(def_id, original_args, span) {
+            AsyncDeterminationResult::Resolved(r) => Ok(r),
+            AsyncDeterminationResult::NotAsync => Ok(self
+                .try_indirect_call_kind(resolved_def_id)
+                .unwrap_or(CallKind::Direct)),
+            AsyncDeterminationResult::Unresolvable(reason) => Err(reason),
+        }
+    }
+
+    fn try_indirect_call_kind(&self, def_id: DefId) -> Option<CallKind<'tcx>> {
+        self.tcx().is_closure(def_id).then_some(CallKind::Indirect)
+    }
+
+    fn terminator_visitor<'b: 'a>(
+        &'b self,
+        state: &'b mut InstructionState<'tcx>,
+        time: Time,
+    ) -> ModularMutationVisitor<'b, 'tcx, impl FnMut(Location, Mutation<'tcx>) + 'b> {
+        let mut vis = self.modular_mutation_visitor(state);
+        vis.set_time(time);
+        vis
+    }
+}
+
+impl<'tcx, 'a> LocalAnalysis<'tcx, 'a> {
+    fn handle_terminator(
+        &mut self,
+        terminator: &Terminator<'tcx>,
+        state: &mut InstructionState<'tcx>,
+        location: Location,
+        time: Time,
+    ) {
+        if let TerminatorKind::Call {
+            func,
+            args,
+            destination,
+            ..
+        } = &terminator.kind
+        {
+            match self.handle_call(
+                state,
+                location,
+                func,
+                args,
+                *destination,
+                terminator.source_info.span,
+            ) {
+                Err(e) => {
+                    self.errors.extend(e);
+                }
+                Ok(false) => {
+                    trace!("Terminator {:?} failed the preamble", terminator.kind);
+                }
+                Ok(true) => return,
+            }
+        }
+        // Fallback: call the visitor
+        self.terminator_visitor(state, time)
+            .visit_terminator(terminator, location)
+    }
+}
+
+impl<'tcx, 'a> df::AnalysisDomain<'tcx> for LocalAnalysis<'tcx, 'a> {
+    type Domain = InstructionState<'tcx>;
+
+    const NAME: &'static str = "LocalPdgConstruction";
+
+    fn bottom_value(&self, _body: &Body<'tcx>) -> Self::Domain {
+        InstructionState::default()
+    }
+
+    fn initialize_start_block(&self, _body: &Body<'tcx>, _state: &mut Self::Domain) {}
+}
+
+impl<'a, 'tcx> df::Analysis<'tcx> for LocalAnalysis<'tcx, 'a> {
+    fn apply_statement_effect(
+        &mut self,
+        state: &mut Self::Domain,
+        statement: &Statement<'tcx>,
+        location: Location,
+    ) {
+        self.modular_mutation_visitor(state)
+            .visit_statement(statement, location)
+    }
+
+    fn apply_terminator_effect<'mir>(
+        &mut self,
+        state: &mut Self::Domain,
+        terminator: &'mir Terminator<'tcx>,
+        location: Location,
+    ) -> TerminatorEdges<'mir, 'tcx> {
+        self.handle_terminator(terminator, state, location, Time::Unspecified);
+        terminator.edges()
+    }
+
+    fn apply_call_return_effect(
+        &mut self,
+        _state: &mut Self::Domain,
+        _block: BasicBlock,
+        _return_places: rustc_middle::mir::CallReturnPlaces<'_, 'tcx>,
+    ) {
+    }
+}
+
+pub enum CallKind<'tcx> {
+    /// A standard function call like `f(x)`.
+    Direct,
+    /// A call to a function variable, like `fn foo(f: impl Fn()) { f() }`
+    Indirect,
+    /// A poll to an async function, like `f.await`.
+    AsyncPoll(Instance<'tcx>, Location, Place<'tcx>),
+}
+
+#[derive(strum::AsRefStr)]
+pub(crate) enum CallHandling<'tcx, 'a> {
+    ApproxAsyncFn,
+    Ready {
+        calling_convention: CallingConvention<'tcx, 'a>,
+        descriptor: &'a PartialGraph<'tcx>,
+    },
+    ApproxAsyncSM(ApproximationHandler<'tcx, 'a>),
+}
+
+fn other_as_arg<'tcx>(place: Place<'tcx>, body: &Body<'tcx>) -> Option<u8> {
+    (body.local_kind(place.local) == rustc_middle::mir::LocalKind::Arg)
+        .then(|| place.local.as_u32() as u8 - 1)
+}

--- a/crates/flowistry_pdg_construction/src/local_analysis.rs
+++ b/crates/flowistry_pdg_construction/src/local_analysis.rs
@@ -383,7 +383,7 @@ impl<'tcx, 'a> LocalAnalysis<'tcx, 'a> {
         trace!("Resolved call to function: {}", self.fmt_fn(called_def_id));
 
         // Monomorphize the called function with the known generic_args.
-        let param_env = tcx.param_env_reveal_all_normalized(self.def_id);
+        let param_env = tcx.param_env(self.def_id);
         let Some(resolved_fn) =
             utils::try_resolve_function(self.tcx(), called_def_id, param_env, generic_args)
         else {
@@ -391,7 +391,7 @@ impl<'tcx, 'a> LocalAnalysis<'tcx, 'a> {
                 self.tcx().sess.span_warn(self.tcx().def_span(called_def_id), format!("could not resolve instance due to dynamic argument: {d:?}"));
                 return None;
             } else {
-                tcx.sess.span_err(span, "instance resolution failed due to unknown reason");
+                tcx.sess.span_err(span, "instance resolution failed: too unspecific");
                 return None;
             }
         };

--- a/crates/flowistry_pdg_construction/src/local_analysis.rs
+++ b/crates/flowistry_pdg_construction/src/local_analysis.rs
@@ -28,7 +28,6 @@ use crate::{
     approximation::ApproximationHandler,
     async_support::*,
     calling_convention::*,
-    construct::PdgCacheKey,
     graph::{DepEdge, DepNode, PartialGraph, SourceUse, TargetUse},
     mutation::{ModularMutationVisitor, Mutation, Time},
     utils::{self, is_async, is_non_default_trait_method, try_monomorphize},

--- a/crates/flowistry_pdg_construction/src/utils.rs
+++ b/crates/flowistry_pdg_construction/src/utils.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use log::trace;
 
 use rustc_hash::{FxHashMap, FxHashSet};
-use rustc_hir::def_id::DefId;
+use rustc_hir::def_id::{self, DefId};
 use rustc_middle::{
     mir::{
         tcx::PlaceTy, Body, HasLocalDecls, Local, Location, Place, ProjectionElem, Statement,
@@ -80,8 +80,9 @@ where
 pub fn type_as_fn<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<(DefId, GenericArgsRef<'tcx>)> {
     let ty = ty_resolve(ty, tcx);
     match ty.kind() {
-        TyKind::FnDef(def_id, generic_args) => Some((*def_id, generic_args)),
-        TyKind::Generator(def_id, generic_args, _) => Some((*def_id, generic_args)),
+        TyKind::FnDef(def_id, generic_args)
+        | TyKind::Generator(def_id, generic_args, _)
+        | TyKind::Closure(def_id, generic_args) => Some((*def_id, generic_args)),
         ty => {
             trace!("Bailing from handle_call because func is literal with type: {ty:?}");
             None

--- a/crates/flowistry_pdg_construction/src/utils.rs
+++ b/crates/flowistry_pdg_construction/src/utils.rs
@@ -1,12 +1,10 @@
-use std::{
-    borrow::Cow, collections::hash_map::Entry, hash::Hash, ops::Deref, ptr::addr_of, sync::OnceLock,
-};
+use std::{collections::hash_map::Entry, hash::Hash};
 
 use either::Either;
-use flowistry_pdg::rustc_portable::LocalDefId;
+
 use itertools::Itertools;
-use log::{debug, trace};
-use rustc_borrowck::consumers::BodyWithBorrowckFacts;
+use log::trace;
+
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_hir::def_id::DefId;
 use rustc_middle::{
@@ -21,8 +19,7 @@ use rustc_middle::{
 };
 use rustc_span::{ErrorGuaranteed, Span};
 use rustc_type_ir::{fold::TypeFoldable, AliasKind};
-use rustc_utils::{cache::Cache, mir, BodyExt, PlaceExt};
-use std::cell::OnceCell;
+use rustc_utils::{BodyExt, PlaceExt};
 
 pub trait Captures<'a> {}
 impl<'a, T: ?Sized> Captures<'a> for T {}

--- a/crates/flowistry_pdg_construction/src/utils.rs
+++ b/crates/flowistry_pdg_construction/src/utils.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use log::trace;
 
 use rustc_hash::{FxHashMap, FxHashSet};
-use rustc_hir::def_id::{self, DefId};
+use rustc_hir::def_id::DefId;
 use rustc_middle::{
     mir::{
         tcx::PlaceTy, Body, HasLocalDecls, Local, Location, Place, ProjectionElem, Statement,
@@ -214,10 +214,10 @@ pub fn ty_resolve<'tcx>(ty: Ty<'tcx>, tcx: TyCtxt<'tcx>) -> Ty<'tcx> {
     }
 }
 
-pub fn manufacture_substs_for<'tcx>(
-    tcx: TyCtxt<'tcx>,
+pub fn manufacture_substs_for(
+    tcx: TyCtxt<'_>,
     function: DefId,
-) -> Result<GenericArgsRef<'tcx>, ErrorGuaranteed> {
+) -> Result<GenericArgsRef<'_>, ErrorGuaranteed> {
     use rustc_middle::ty::{
         BoundRegionKind, DynKind, ExistentialPredicate, ExistentialProjection, ExistentialTraitRef,
         GenericParamDefKind, ImplPolarity, ParamTy, TraitPredicate,

--- a/crates/flowistry_pdg_construction/src/utils.rs
+++ b/crates/flowistry_pdg_construction/src/utils.rs
@@ -19,89 +19,26 @@ use rustc_span::ErrorGuaranteed;
 use rustc_type_ir::{fold::TypeFoldable, AliasKind};
 use rustc_utils::{BodyExt, PlaceExt};
 
-#[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
-pub enum FnResolution<'tcx> {
-    Final(ty::Instance<'tcx>),
-    Partial(DefId),
+pub trait Captures<'a> {}
+impl<'a, T: ?Sized> Captures<'a> for T {}
+
+/// An async check that does not crash if called on closures.
+pub fn is_async(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
+    !tcx.is_closure(def_id) && tcx.asyncness(def_id).is_async()
 }
 
-impl<'tcx> PartialOrd for FnResolution<'tcx> {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<'tcx> Ord for FnResolution<'tcx> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        use FnResolution::*;
-        match (self, other) {
-            (Final(_), Partial(_)) => std::cmp::Ordering::Greater,
-            (Partial(_), Final(_)) => std::cmp::Ordering::Less,
-            (Partial(slf), Partial(otr)) => slf.cmp(otr),
-            (Final(slf), Final(otr)) => match slf.def.cmp(&otr.def) {
-                std::cmp::Ordering::Equal => slf.args.cmp(otr.args),
-                result => result,
-            },
-        }
-    }
-}
-
-impl<'tcx> FnResolution<'tcx> {
-    pub fn def_id(self) -> DefId {
-        match self {
-            FnResolution::Final(f) => f.def_id(),
-            FnResolution::Partial(p) => p,
-        }
-    }
-}
-
-impl<'tcx> std::fmt::Display for FnResolution<'tcx> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            FnResolution::Final(sub) => std::fmt::Debug::fmt(sub, f),
-            FnResolution::Partial(p) => std::fmt::Debug::fmt(p, f),
-        }
-    }
-}
-
-/// Try and normalize the provided generics.
-///
-/// The purpose of this function is to test whether resolving these generics
-/// will return an error. We need this because [`ty::Instance::resolve`] fails
-/// with a hard error when this normalization fails (even though it returns
-/// [`Result`]). However legitimate situations can arise in the code where this
-/// normalization fails for which we want to report warnings but carry on with
-/// the analysis which a hard error doesn't allow us to do.
-fn test_generics_normalization<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    param_env: ParamEnv<'tcx>,
-    args: &'tcx ty::List<ty::GenericArg<'tcx>>,
-) -> Result<(), ty::normalize_erasing_regions::NormalizationError<'tcx>> {
-    tcx.try_normalize_erasing_regions(param_env, args)
-        .map(|_| ())
-}
-
+/// Resolve the `def_id` item to an instance.
 pub fn try_resolve_function<'tcx>(
     tcx: TyCtxt<'tcx>,
     def_id: DefId,
     param_env: ParamEnv<'tcx>,
     args: GenericArgsRef<'tcx>,
-) -> FnResolution<'tcx> {
+) -> Option<Instance<'tcx>> {
     let param_env = param_env.with_reveal_all_normalized(tcx);
-    let make_opt = || {
-        if let Err(e) = test_generics_normalization(tcx, param_env, args) {
-            debug!("Normalization failed: {e:?}");
-            return None;
-        }
-        Instance::resolve(tcx, param_env, def_id, args).unwrap()
-    };
-
-    match make_opt() {
-        Some(inst) => FnResolution::Final(inst),
-        None => FnResolution::Partial(def_id),
-    }
+    Instance::resolve(tcx, param_env, def_id, args).unwrap()
 }
 
+/// Returns the default implementation of this method if it is a trait method.
 pub fn is_non_default_trait_method(tcx: TyCtxt, function: DefId) -> Option<DefId> {
     let assoc_item = tcx.opt_associated_item(function)?;
     if assoc_item.container != ty::AssocItemContainer::TraitContainer
@@ -112,23 +49,16 @@ pub fn is_non_default_trait_method(tcx: TyCtxt, function: DefId) -> Option<DefId
     assoc_item.trait_item_def_id
 }
 
-impl<'tcx> FnResolution<'tcx> {
-    pub fn try_monomorphize<'a, T>(
-        self,
-        tcx: TyCtxt<'tcx>,
-        param_env: ParamEnv<'tcx>,
-        t: &'a T,
-    ) -> Cow<'a, T>
-    where
-        T: TypeFoldable<TyCtxt<'tcx>> + Clone,
-    {
-        match self {
-            FnResolution::Partial(_) => Cow::Borrowed(t),
-            FnResolution::Final(inst) => Cow::Owned(inst.subst_mir_and_normalize_erasing_regions(
-                tcx,
-                param_env,
-                EarlyBinder::bind(tcx.erase_regions(t.clone())),
-            )),
+/// Attempt to interpret this type as a statically determinable function and its
+/// generic arguments.
+pub fn type_as_fn<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<(DefId, GenericArgsRef<'tcx>)> {
+    let ty = ty_resolve(ty, tcx);
+    match ty.kind() {
+        TyKind::FnDef(def_id, generic_args) => Some((*def_id, generic_args)),
+        TyKind::Generator(def_id, generic_args, _) => Some((*def_id, generic_args)),
+        ty => {
+            trace!("Bailing from handle_call because func is literal with type: {ty:?}");
+            None
         }
     }
 }

--- a/crates/flowistry_pdg_construction/src/utils.rs
+++ b/crates/flowistry_pdg_construction/src/utils.rs
@@ -73,7 +73,7 @@ where
     .map_err(|e| {
         tcx.sess.span_err(
             span,
-            "failed to monomorphize with instance {inst:?} due to {e:?}",
+            format!("failed to monomorphize with instance {inst:?} due to {e:?}"),
         )
     })
 }

--- a/crates/flowistry_pdg_construction/tests/pdg.rs
+++ b/crates/flowistry_pdg_construction/tests/pdg.rs
@@ -170,10 +170,11 @@ macro_rules! pdg_constraint {
 }
 
 macro_rules! pdg_test {
-  ($name:ident, { $($i:item)* }, $($cs:tt),*) => {
+  ($(#[$($attr:tt)+])* $name:ident, { $($i:item)* }, $($cs:tt),*) => {
     pdg_test!($name, { $($i)* }, |_, _| (), $($cs),*);
   };
-  ($name:ident, { $($i:item)* }, $e:expr, $($cs:tt),*) => {
+  ($(#[$($attr:tt)+])* $name:ident, { $($i:item)* }, $e:expr, $($cs:tt),*) => {
+    $(#[$($attr)+])*
     #[test]
     fn $name() {
       let input = stringify!($($i)*);
@@ -785,6 +786,7 @@ pdg_test! {
 }
 
 pdg_test! {
+  #[ignore = "Fixme"]
   spawn_and_loop_await,
   {
     use std::future::Future;

--- a/crates/flowistry_pdg_construction/tests/pdg.rs
+++ b/crates/flowistry_pdg_construction/tests/pdg.rs
@@ -3,13 +3,14 @@
 extern crate either;
 extern crate rustc_hir;
 extern crate rustc_middle;
+extern crate rustc_span;
 
 use std::collections::HashSet;
 
 use either::Either;
 use flowistry_pdg_construction::{
     graph::{DepEdge, DepGraph},
-    CallChangeCallbackFn, CallChanges, PdgParams, SkipCall,
+    CallChangeCallbackFn, CallChanges, MemoPdgConstructor, SkipCall,
 };
 use itertools::Itertools;
 use rustc_hir::def_id::LocalDefId;
@@ -17,6 +18,7 @@ use rustc_middle::{
     mir::{Terminator, TerminatorKind},
     ty::TyCtxt,
 };
+use rustc_span::Symbol;
 use rustc_utils::{
     mir::borrowck_facts, source_map::find_bodies::find_bodies, test_utils::CompileResult,
 };
@@ -34,14 +36,15 @@ fn get_main(tcx: TyCtxt<'_>) -> LocalDefId {
 
 fn pdg(
     input: impl Into<String>,
-    configure: impl for<'tcx> FnOnce(TyCtxt<'tcx>, PdgParams<'tcx>) -> PdgParams<'tcx> + Send,
+    configure: impl for<'tcx> FnOnce(TyCtxt<'tcx>, &mut MemoPdgConstructor<'tcx>) + Send,
     tests: impl for<'tcx> FnOnce(TyCtxt<'tcx>, DepGraph<'tcx>) + Send,
 ) {
     let _ = env_logger::try_init();
     rustc_utils::test_utils::CompileBuilder::new(input).compile(move |CompileResult { tcx }| {
         let def_id = get_main(tcx);
-        let params = configure(tcx, PdgParams::new(tcx, def_id).unwrap());
-        let pdg = flowistry_pdg_construction::compute_pdg(params);
+        let mut memo = MemoPdgConstructor::new(tcx);
+        configure(tcx, &mut memo);
+        let pdg = memo.construct_graph(def_id);
         tests(tcx, pdg)
     })
 }
@@ -168,7 +171,7 @@ macro_rules! pdg_constraint {
 
 macro_rules! pdg_test {
   ($name:ident, { $($i:item)* }, $($cs:tt),*) => {
-    pdg_test!($name, { $($i)* }, |_, params| params, $($cs),*);
+    pdg_test!($name, { $($i)* }, |_, _| (), $($cs),*);
   };
   ($name:ident, { $($i:item)* }, $e:expr, $($cs:tt),*) => {
     #[test]
@@ -612,7 +615,7 @@ pdg_test! {
     |_, params| {
         params.with_call_change_callback(CallChangeCallbackFn::new( move |_| {
             CallChanges::default().with_skip(SkipCall::Skip)
-        }))
+        }));
     },
     (recipients -/> sender)
 }
@@ -638,7 +641,8 @@ pdg_test! {
       nested_layer_one(&mut w, z);
     }
   },
-  |tcx, params| params.with_call_change_callback(CallChangeCallbackFn::new(move |info| {
+  |tcx, params| {
+      params.with_call_change_callback(CallChangeCallbackFn::new(move |info| {
       let name = tcx.opt_item_name(info.callee.def_id());
       let skip = if !matches!(name.as_ref().map(|sym| sym.as_str()), Some("no_inline"))
           && info.call_string.len() < 2
@@ -648,9 +652,12 @@ pdg_test! {
           SkipCall::Skip
       };
       CallChanges::default().with_skip(skip)
-  })),
-  (y -> x),
-  (z -> w)
+    }));
+  },
+  (y -> x)
+  // TODO the way that graphs are constructed currently doesn't allow limiting
+  // call string depth
+  // (z -> w)
 }
 
 pdg_test! {
@@ -775,4 +782,61 @@ pdg_test! {
             t.method()
         }
     },
+}
+
+pdg_test! {
+  spawn_and_loop_await,
+  {
+    use std::future::Future;
+    use std::task::{Poll, Context};
+    use std::pin::Pin;
+
+    struct JoinHandle<T>(Box<dyn Future<Output=T>>);
+
+    impl<T> Future for JoinHandle<T> {
+      type Output = T;
+      fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.map_unchecked_mut(|p| p.0.as_mut()).poll(cx)
+      }
+    }
+
+    pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
+    where
+      F: Future + Send + 'static,
+      F::Output: Send + 'static,
+    {
+      JoinHandle(Box::new(future))
+    }
+
+    pub async fn main() {
+      let mut tasks = vec![];
+      for i in [0,1] {
+        let task: JoinHandle<_> = spawn(async move {
+          println!("{i}");
+          Ok::<_, String>(0)
+        });
+        tasks.push(task);
+      }
+
+      for h in tasks {
+        if let Err(e) = h.await {
+          panic!("{e}")
+        }
+      }
+    }
+  },
+  |tcx, params| {
+      params.with_call_change_callback(CallChangeCallbackFn::new(move |info| {
+        let name = tcx.opt_item_name(info.callee.def_id());
+        let name2 = tcx.opt_parent(info.callee.def_id()).and_then(|c| tcx.opt_item_name(c));
+        let is_spawn = |name: Option<&Symbol>| name.map_or(false, |n| n.as_str().contains("spawn"));
+        let mut changes = CallChanges::default();
+        if is_spawn(name.as_ref()) || is_spawn(name2.as_ref())
+        {
+          changes = changes.with_skip(SkipCall::Skip);
+        };
+        changes
+    }));
+  },
+  (i -> h)
 }

--- a/crates/paralegal-flow/src/ana/graph_converter.rs
+++ b/crates/paralegal-flow/src/ana/graph_converter.rs
@@ -1,15 +1,10 @@
-use std::{
-    cell::RefCell,
-    fmt::Display,
-    rc::Rc,
-    time::{Duration, Instant},
-};
+use std::{rc::Rc, time::Instant};
 
 use self::call_string_resolver::CallStringResolver;
 use super::{default_index, path_for_item, src_loc_for_span, SPDGGenerator};
 use crate::{
-    ana::inline_judge::InlineJudge, ann::MarkerAnnotation, desc::*, discover::FnToAnalyze,
-    stats::TimedStat, utils::*, HashMap, HashSet, MarkerCtx,
+    ann::MarkerAnnotation, desc::*, discover::FnToAnalyze, stats::TimedStat, utils::*, HashMap,
+    HashSet, MarkerCtx,
 };
 use flowistry_pdg::SourceUse;
 use flowistry_pdg_construction::{
@@ -17,11 +12,8 @@ use flowistry_pdg_construction::{
     graph::{DepEdge, DepEdgeKind, DepGraph, DepNode},
     is_async_trait_fn, match_async_trait_assign,
     utils::try_monomorphize,
-    CallChangeCallback, CallChanges, CallInfo, InlineMissReason,
-    SkipCall::Skip,
 };
 use paralegal_spdg::{Node, SPDGStats};
-use rustc_utils::cache::Cache;
 
 use rustc_hir::{
     def,
@@ -32,9 +24,9 @@ use rustc_middle::{
     ty::{self, TyCtxt},
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use either::Either;
-use flowistry::mir::placeinfo::PlaceInfo;
+
 use petgraph::{
     visit::{IntoNodeReferences, NodeIndexable, NodeRef},
     Direction,
@@ -595,7 +587,7 @@ mod call_string_resolver {
     use flowistry_pdg_construction::utils::{
         manufacture_substs_for, try_monomorphize, try_resolve_function,
     };
-    use rustc_middle::ty::{Instance, ParamEnv};
+    use rustc_middle::ty::Instance;
     use rustc_utils::cache::Cache;
 
     use crate::{Either, TyCtxt};

--- a/crates/paralegal-flow/src/ana/graph_converter.rs
+++ b/crates/paralegal-flow/src/ana/graph_converter.rs
@@ -179,7 +179,7 @@ impl<'a, 'tcx, C: Extend<DefId>> GraphConverter<'tcx, 'a, C> {
                     return;
                 };
                 let res = self.call_string_resolver.resolve(weight.at);
-                let param_env = self.tcx().param_env_reveal_all_normalized(res.def_id());
+                let param_env = self.tcx().param_env(res.def_id());
                 let f = try_monomorphize(res, self.tcx(), param_env, term, term.source_info.span)
                     .unwrap()
                     .as_instance_and_args(self.tcx())

--- a/crates/paralegal-flow/src/ana/mod.rs
+++ b/crates/paralegal-flow/src/ana/mod.rs
@@ -35,7 +35,7 @@ mod inline_judge;
 
 use graph_converter::GraphConverter;
 
-use self::{graph_converter::PlaceInfoCache, inline_judge::InlineJudge};
+use self::inline_judge::InlineJudge;
 
 /// Read-only database of information the analysis needs.
 ///
@@ -45,7 +45,6 @@ pub struct SPDGGenerator<'tcx> {
     pub opts: &'static crate::Args,
     pub tcx: TyCtxt<'tcx>,
     stats: Stats,
-    place_info_cache: PlaceInfoCache<'tcx>,
     pdg_constructor: MemoPdgConstructor<'tcx>,
 }
 
@@ -70,7 +69,6 @@ impl<'tcx> SPDGGenerator<'tcx> {
             opts,
             tcx,
             stats,
-            place_info_cache: Default::default(),
         }
     }
 
@@ -91,12 +89,7 @@ impl<'tcx> SPDGGenerator<'tcx> {
         info!("Handling target {}", self.tcx.def_path_str(target.def_id));
         let local_def_id = target.def_id;
 
-        let converter = GraphConverter::new_with_flowistry(
-            self,
-            known_def_ids,
-            target,
-            self.place_info_cache.clone(),
-        )?;
+        let converter = GraphConverter::new_with_flowistry(self, known_def_ids, target)?;
         let spdg = converter.make_spdg();
 
         Ok((local_def_id, spdg))

--- a/crates/paralegal-flow/src/ana/mod.rs
+++ b/crates/paralegal-flow/src/ana/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     HashMap, HashSet, LogLevelConfig, MarkerCtx,
 };
 
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use anyhow::Result;
 use either::Either;
@@ -23,11 +23,8 @@ use flowistry_pdg_construction::{
 use itertools::Itertools;
 use petgraph::visit::GraphBase;
 
-use rustc_hir::{
-    self as hir, def,
-    def_id::{DefId, LocalDefId},
-};
-use rustc_middle::ty::{self, TyCtxt};
+use rustc_hir::{self as hir, def, def_id::DefId};
+use rustc_middle::ty::TyCtxt;
 use rustc_span::{FileNameDisplayPreference, Span as RustSpan, Symbol};
 
 mod graph_converter;

--- a/crates/paralegal-flow/src/ana/mod.rs
+++ b/crates/paralegal-flow/src/ana/mod.rs
@@ -8,19 +8,27 @@ use crate::{
     ann::{Annotation, MarkerAnnotation},
     desc::*,
     discover::FnToAnalyze,
-    rust::{hir::def, *},
     stats::{Stats, TimedStat},
     utils::*,
-    DefId, HashMap, HashSet, LogLevelConfig, MarkerCtx, Symbol,
+    HashMap, HashSet, LogLevelConfig, MarkerCtx,
 };
 
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use either::Either;
+use flowistry_pdg_construction::{
+    CallChangeCallback, CallChanges, CallInfo, MemoPdgConstructor, SkipCall,
+};
 use itertools::Itertools;
 use petgraph::visit::GraphBase;
-use rustc_span::{FileNameDisplayPreference, Span as RustSpan};
+
+use rustc_hir::{
+    self as hir, def,
+    def_id::{DefId, LocalDefId},
+};
+use rustc_middle::ty::{self, TyCtxt};
+use rustc_span::{FileNameDisplayPreference, Span as RustSpan, Symbol};
 
 mod graph_converter;
 mod inline_judge;
@@ -38,6 +46,7 @@ pub struct SPDGGenerator<'tcx> {
     pub tcx: TyCtxt<'tcx>,
     stats: Stats,
     place_info_cache: PlaceInfoCache<'tcx>,
+    pdg_constructor: MemoPdgConstructor<'tcx>,
 }
 
 impl<'tcx> SPDGGenerator<'tcx> {
@@ -47,8 +56,17 @@ impl<'tcx> SPDGGenerator<'tcx> {
         tcx: TyCtxt<'tcx>,
         stats: Stats,
     ) -> Self {
+        let inline_judge = InlineJudge::new(marker_ctx, tcx, opts.anactrl());
+        let mut pdg_constructor = MemoPdgConstructor::new(tcx);
+        pdg_constructor
+            .with_call_change_callback(MyCallback {
+                judge: inline_judge.clone(),
+                tcx,
+            })
+            .with_dump_mir(opts.dbg().dump_mir());
         Self {
-            inline_judge: InlineJudge::new(marker_ctx, tcx, opts.anactrl()),
+            inline_judge,
+            pdg_constructor,
             opts,
             tcx,
             stats,
@@ -71,7 +89,7 @@ impl<'tcx> SPDGGenerator<'tcx> {
         known_def_ids: &mut impl Extend<DefId>,
     ) -> Result<(Endpoint, SPDG)> {
         info!("Handling target {}", self.tcx.def_path_str(target.def_id));
-        let local_def_id = target.def_id.expect_local();
+        let local_def_id = target.def_id;
 
         let converter = GraphConverter::new_with_flowistry(
             self,
@@ -433,3 +451,98 @@ fn with_reset_level_if_target<R, F: FnOnce() -> R>(opts: &crate::Args, target: S
         f()
     }
 }
+
+struct MyCallback<'tcx> {
+    judge: InlineJudge<'tcx>,
+    // stat_wrap: StatStracker,
+    tcx: TyCtxt<'tcx>,
+}
+
+impl<'tcx> CallChangeCallback<'tcx> for MyCallback<'tcx> {
+    fn on_inline(&self, info: CallInfo<'tcx>) -> CallChanges {
+        let mut changes = CallChanges::default();
+
+        let mut skip = true;
+
+        if is_non_default_trait_method(self.tcx, info.callee.def_id()).is_some() {
+            self.tcx.sess.span_warn(
+                self.tcx.def_span(info.callee.def_id()),
+                "Skipping analysis of unresolvable trait method.",
+            );
+        } else if self.judge.should_inline(&info) {
+            skip = false;
+        };
+
+        if skip {
+            changes = changes.with_skip(SkipCall::Skip);
+        } else {
+            // record_inlining(
+            //     &self.stat_wrap,
+            //     self.tcx,
+            //     info.callee.def_id().expect_local(),
+            //     info.is_cached,
+            // )
+        }
+        changes
+    }
+
+    // fn on_inline_miss(
+    //     &self,
+    //     resolution: FnResolution<'tcx>,
+    //     loc: Location,
+    //     parent: FnResolution<'tcx>,
+    //     call_string: Option<CallString>,
+    //     reason: InlineMissReason,
+    // ) {
+    //     let body = self
+    //         .tcx
+    //         .body_for_def_id(parent.def_id().expect_local())
+    //         .unwrap();
+    //     let span = body
+    //         .body
+    //         .stmt_at(loc)
+    //         .either(|s| s.source_info.span, |t| t.source_info.span);
+    //     let markers_reachable = self.judge.marker_ctx().get_reachable_markers(resolution);
+    //     self.tcx.sess.span_err(
+    //         span,
+    //         format!(
+    //             "Could not inline this function call in {:?}, at {} because {reason:?}. {}",
+    //             parent.def_id(),
+    //             call_string.map_or("root".to_owned(), |c| c.to_string()),
+    //             Print(|f| if markers_reachable.is_empty() {
+    //                 f.write_str("No markers are reachable")
+    //             } else {
+    //                 f.write_str("Markers ")?;
+    //                 write_sep(f, ", ", markers_reachable.iter(), Display::fmt)?;
+    //                 f.write_str(" are reachable")
+    //             })
+    //         ),
+    //     );
+    // }
+}
+
+//type StatStracker = Rc<RefCell<(SPDGStats, HashSet<LocalDefId>)>>;
+
+// fn record_inlining(tracker: &StatStracker, tcx: TyCtxt<'_>, def_id: LocalDefId, is_in_cache: bool) {
+//     let mut borrow = tracker.borrow_mut();
+//     let (stats, loc_set) = &mut *borrow;
+//     stats.inlinings_performed += 1;
+//     let is_new = loc_set.insert(def_id);
+
+//     if !is_new || is_in_cache {
+//         return;
+//     }
+
+//     let src_map = tcx.sess.source_map();
+//     let span = body_span(&tcx.body_for_def_id(def_id).unwrap().body);
+//     let (_, start_line, _, end_line, _) = src_map.span_to_location_info(span);
+//     let body_lines = (end_line - start_line + 1) as u32;
+//     if is_new {
+//         stats.unique_functions += 1;
+//         stats.unique_locs += body_lines;
+//     }
+//     if !is_in_cache {
+//         stats.analyzed_functions += 1;
+//         stats.analyzed_locs += body_lines;
+//     }
+// }

--- a/crates/paralegal-flow/src/ann/db.rs
+++ b/crates/paralegal-flow/src/ann/db.rs
@@ -20,7 +20,10 @@ use crate::{
     },
     Either, HashMap, HashSet,
 };
-use flowistry_pdg_construction::{determine_async, utils::try_monomorphize};
+use flowistry_pdg_construction::{
+    determine_async,
+    utils::{try_monomorphize, try_resolve_function},
+};
 use paralegal_spdg::Identifier;
 use rustc_utils::cache::Cache;
 
@@ -268,7 +271,7 @@ impl<'tcx> MarkerCtx<'tcx> {
                 && let ty::TyKind::Generator(closure_fn, substs, _) = self.tcx().type_of(alias.def_id).skip_binder().kind() {
                 trace!("    fits opaque type");
                 Either::Left(self.get_reachable_and_self_markers(
-                    ty::Instance::expect_resolve(self.tcx(), ty::ParamEnv::reveal_all(), *closure_fn, substs)
+                    try_resolve_function(self.tcx(), *closure_fn, ty::ParamEnv::reveal_all(), substs).unwrap()
                 ))
             } else {
                 Either::Right(std::iter::empty())

--- a/crates/paralegal-flow/src/ann/parse.rs
+++ b/crates/paralegal-flow/src/ann/parse.rs
@@ -12,14 +12,15 @@ use super::{
     ExceptionAnnotation, MarkerAnnotation, MarkerRefinement, MarkerRefinementKind, VerificationHash,
 };
 use crate::{
-    consts,
-    rust::*,
-    utils,
+    consts, utils,
     utils::{write_sep, Print, TinyBitSet},
     Symbol,
 };
-use ast::{token, tokenstream};
 use paralegal_spdg::Identifier;
+
+use rustc_ast::{self as ast, token, tokenstream};
+use rustc_hir::def_id::DefId;
+use rustc_middle::ty::TyCtxt;
 use token::*;
 use tokenstream::*;
 

--- a/crates/paralegal-flow/src/dbg.rs
+++ b/crates/paralegal-flow/src/dbg.rs
@@ -8,7 +8,7 @@
 //! to stdout, a file or a log statement. Some take additional information (such
 //! as [TyCtxt]) to get contextual information that is used to make the output
 //! more useful.
-use crate::rust::mir;
+use rustc_middle::mir;
 
 /// All locations that a body has (helper)
 pub fn locations_of_body<'a: 'tcx, 'tcx>(

--- a/crates/paralegal-flow/src/lib.rs
+++ b/crates/paralegal-flow/src/lib.rs
@@ -23,49 +23,27 @@ extern crate petgraph;
 extern crate num_derive;
 extern crate num_traits;
 
-pub extern crate rustc_index;
+extern crate rustc_abi;
+extern crate rustc_arena;
+extern crate rustc_ast;
+extern crate rustc_borrowck;
+extern crate rustc_data_structures;
+extern crate rustc_driver;
+extern crate rustc_hir;
+extern crate rustc_index;
+extern crate rustc_interface;
+extern crate rustc_middle;
+extern crate rustc_mir_dataflow;
+extern crate rustc_query_system;
 extern crate rustc_serialize;
-
-pub mod rust {
-    //! Exposes the rustc external crates (this mod is just to tidy things up).
-    pub extern crate rustc_abi;
-    pub extern crate rustc_arena;
-    pub extern crate rustc_ast;
-    pub extern crate rustc_borrowck;
-    pub extern crate rustc_data_structures;
-    pub extern crate rustc_driver;
-    pub extern crate rustc_hir;
-    pub extern crate rustc_interface;
-    pub extern crate rustc_middle;
-    pub extern crate rustc_mir_dataflow;
-    pub extern crate rustc_query_system;
-    pub extern crate rustc_serialize;
-    pub extern crate rustc_span;
-    pub extern crate rustc_target;
-    pub extern crate rustc_type_ir;
-    pub use super::rustc_index;
-    pub use rustc_type_ir::sty;
-
-    pub use rustc_ast as ast;
-    pub mod mir {
-        pub use super::rustc_abi::FieldIdx as Field;
-        pub use super::rustc_middle::mir::*;
-    }
-    pub use rustc_hir as hir;
-    pub use rustc_middle::ty;
-
-    pub use rustc_middle::dep_graph::DepGraph;
-    pub use ty::TyCtxt;
-
-    pub use hir::def_id::{DefId, LocalDefId};
-    pub use hir::BodyId;
-    pub use mir::Location;
-}
+extern crate rustc_span;
+extern crate rustc_target;
+extern crate rustc_type_ir;
 
 use args::{ClapArgs, Debugger, LogLevelConfig};
 use desc::{utils::write_sep, ProgramDescription};
-use rust::*;
 
+use rustc_middle::ty::TyCtxt;
 use rustc_plugin::CrateFilter;
 use rustc_utils::mir::borrowck_facts;
 pub use std::collections::{HashMap, HashSet};
@@ -128,8 +106,8 @@ struct ArgWrapper {
 
 struct Callbacks {
     opts: &'static Args,
-    stats: Stats,
     start: Instant,
+    stats: Stats,
 }
 
 struct NoopCallbacks {}

--- a/crates/paralegal-flow/src/test_utils.rs
+++ b/crates/paralegal-flow/src/test_utils.rs
@@ -4,6 +4,8 @@ extern crate rustc_hir as hir;
 extern crate rustc_middle;
 extern crate rustc_span;
 
+use hir::def_id::DefId;
+
 use crate::{
     desc::{Identifier, ProgramDescription},
     HashSet,
@@ -13,7 +15,6 @@ use std::hash::{Hash, Hasher};
 use std::process::Command;
 
 use paralegal_spdg::{
-    rustc_portable::DefId,
     traverse::{generic_flows_to, EdgeSelection},
     DefInfo, EdgeInfo, Node, SPDG,
 };
@@ -330,7 +331,7 @@ pub trait HasGraph<'g>: Sized + Copy {
 #[derive(Debug)]
 pub struct PreFrg {
     pub desc: ProgramDescription,
-    pub name_map: crate::HashMap<Identifier, Vec<crate::DefId>>,
+    pub name_map: crate::HashMap<Identifier, Vec<DefId>>,
 }
 
 impl<'g> HasGraph<'g> for &'g PreFrg {

--- a/crates/paralegal-flow/src/utils/mod.rs
+++ b/crates/paralegal-flow/src/utils/mod.rs
@@ -20,7 +20,7 @@ use rustc_hir::{
 };
 use rustc_middle::{
     mir::{self, Location, Place, ProjectionElem},
-    ty::{self, normalize_erasing_regions::NormalizationError, Instance},
+    ty::{self, Instance},
 };
 use rustc_span::{symbol::Ident, Span as RustSpan, Span};
 use rustc_target::spec::abi::Abi;

--- a/crates/paralegal-flow/src/utils/mod.rs
+++ b/crates/paralegal-flow/src/utils/mod.rs
@@ -359,7 +359,7 @@ impl<'tcx> AsFnAndArgs<'tcx> for mir::Terminator<'tcx> {
         let Some((def_id, gargs)) = type_as_fn(tcx, ty) else {
             return Err(AsFnAndArgsErr::NotFunctionType(ty.kind().clone()));
         };
-        let _ = test_generics_normalization(tcx, gargs)
+        test_generics_normalization(tcx, gargs)
             .map_err(|e| AsFnAndArgsErr::NormalizationError(format!("{e:?}")))?;
         let instance = ty::Instance::resolve(tcx, ty::ParamEnv::reveal_all(), def_id, gargs)
             .map_err(|_| AsFnAndArgsErr::InstanceResolutionErr)?

--- a/crates/paralegal-flow/src/utils/mod.rs
+++ b/crates/paralegal-flow/src/utils/mod.rs
@@ -327,7 +327,7 @@ pub enum AsFnAndArgsErr<'tcx> {
     InstanceResolutionErr,
     #[error("could not normalize generics {0}")]
     NormalizationError(String),
-    #[error("instance to unspecific")]
+    #[error("instance too unspecific")]
     InstanceTooUnspecific,
 }
 

--- a/crates/paralegal-flow/src/utils/resolve.rs
+++ b/crates/paralegal-flow/src/utils/resolve.rs
@@ -8,7 +8,7 @@ use hir::{
 };
 use rustc_ast as ast;
 use rustc_hir::{self as hir, def_id::DefId};
-use rustc_middle::ty::{self, fast_reject::SimplifiedType, FloatTy, IntTy, TyCtxt, UintTy};
+use rustc_middle::ty::{fast_reject::SimplifiedType, FloatTy, IntTy, TyCtxt, UintTy};
 use rustc_span::Symbol;
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/paralegal-flow/src/utils/resolve.rs
+++ b/crates/paralegal-flow/src/utils/resolve.rs
@@ -1,4 +1,3 @@
-use crate::{ast, hir, ty, DefId, Symbol, TyCtxt};
 use ast::Mutability;
 use hir::{
     def::{self, DefKind},
@@ -7,7 +6,10 @@ use hir::{
     def_id::LOCAL_CRATE,
     ImplItemRef, ItemKind, Node, PrimTy, TraitItemRef,
 };
-use ty::{fast_reject::SimplifiedType, FloatTy, IntTy, UintTy};
+use rustc_ast as ast;
+use rustc_hir::{self as hir, def_id::DefId};
+use rustc_middle::ty::{self, fast_reject::SimplifiedType, FloatTy, IntTy, TyCtxt, UintTy};
+use rustc_span::Symbol;
 
 #[derive(Debug, Clone, Copy)]
 pub enum Res {

--- a/crates/paralegal-flow/tests/async_tests.rs
+++ b/crates/paralegal-flow/tests/async_tests.rs
@@ -384,11 +384,11 @@ fn async_through_another_layer() {
         }
     ))
     .check(|ctrl| {
-        assert!(!ctrl
-            .marked(Identifier::new_intern("source"))
-            .flows_to_any(&ctrl.marked(Identifier::new_intern("sink"))));
-        assert!(ctrl
-            .marked(Identifier::new_intern("source_2"))
-            .flows_to_any(&ctrl.marked(Identifier::new_intern("sink"))));
+        let sources = ctrl.marked(Identifier::new_intern("source"));
+        let sinks = ctrl.marked(Identifier::new_intern("source_2"));
+        assert!(!sources.is_empty());
+        assert!(!sinks.is_empty());
+        assert!(!sources.flows_to_any(&ctrl.marked(Identifier::new_intern("sink"))));
+        assert!(sinks.flows_to_any(&ctrl.marked(Identifier::new_intern("sink"))));
     })
 }

--- a/crates/paralegal-flow/tests/async_tests.rs
+++ b/crates/paralegal-flow/tests/async_tests.rs
@@ -289,6 +289,7 @@ fn await_on_generic() {
 }
 
 #[test]
+#[ignore = "https://github.com/brownsys/paralegal/issues/159"]
 fn await_with_inner_generic() {
     InlineTestBuilder::new(stringify!(
         use std::{

--- a/crates/paralegal-flow/tests/call_chain_analysis_tests.rs
+++ b/crates/paralegal-flow/tests/call_chain_analysis_tests.rs
@@ -28,16 +28,33 @@ define_test!(without_return: ctrl -> {
     assert!(src.output().flows_to_data(&dest));
 });
 
-define_test!(with_return: ctrl -> {
-    let src_fn = ctrl.function("source");
-    let src = ctrl.call_site(&src_fn);
-    let ctrl = ctrl.ctrl("with_return");
-    let dest_fn = ctrl.function("receiver");
-    let dest_sink = ctrl.call_site(&dest_fn);
-    let dest = dest_sink.input().nth(0).unwrap();
+#[test]
+fn with_return() {
+    InlineTestBuilder::new(stringify!(
+        #[paralegal_flow::marker(hello, return)]
+        fn source() -> i32 {
+            0
+        }
+        fn callee(x: i32) -> i32 {
+            source()
+        }
+        #[paralegal_flow::marker(there, arguments = [0])]
+        fn receiver(x: i32) {}
 
-    assert!(src.output().flows_to_data(&dest));
-});
+        fn main(x: i32) {
+            receiver(callee(x));
+        }
+    ))
+    .check(|ctrl| {
+        let src_fn = ctrl.function("source");
+        let src = ctrl.call_site(&src_fn);
+        let dest_fn = ctrl.function("receiver");
+        let dest_sink = ctrl.call_site(&dest_fn);
+        let dest = dest_sink.input().nth(0).unwrap();
+
+        assert!(src.output().flows_to_data(&dest));
+    })
+}
 
 define_test!(on_mut_var: ctrl -> {
     let src_fn = ctrl.function("source");

--- a/crates/paralegal-flow/tests/clone-test.rs
+++ b/crates/paralegal-flow/tests/clone-test.rs
@@ -1,0 +1,78 @@
+use paralegal_flow::test_utils::InlineTestBuilder;
+
+#[test]
+fn clone_nesting() {
+    InlineTestBuilder::new(stringify!(
+        #[derive(Clone)]
+        enum Opt<T> {
+            Empty,
+            Filled(T),
+        }
+
+        #[derive(Clone)]
+        struct AStruct {
+            f: usize,
+            g: usize,
+        }
+
+        #[derive(Clone)]
+        enum AnEnum {
+            Var1(usize),
+            Var2(String),
+        }
+
+        fn main() {
+            let v0 = Opt::Filled(AStruct { f: 0, g: 0 }).clone();
+            let v2 = Opt::Filled(AnEnum::Var1(0)).clone();
+        }
+    ))
+    .check(|_ctr| {})
+}
+
+#[test]
+fn clone_test_2() {
+    InlineTestBuilder::new(stringify!(
+        #[derive(Clone)]
+        pub(crate) enum IdOrNestedObject<Kind> {
+            Id(Url),
+            NestedObject(Kind),
+        }
+
+        #[derive(Clone)]
+        struct Url(String);
+
+        #[derive(Clone)]
+        pub struct Vote {
+            pub(crate) to: Vec<VoteUrl>,
+        }
+
+        #[derive(Clone)]
+        struct VoteUrl(String);
+
+        #[derive(Clone)]
+        struct TombstoneUrl(String);
+
+        #[derive(Clone)]
+        pub struct AnnounceActivity {
+            pub(crate) object: IdOrNestedObject<AnnouncableActivities>,
+        }
+        #[derive(Clone)]
+        pub struct Tombstone {
+            pub(crate) id: TombstoneUrl,
+        }
+
+        #[derive(Clone)]
+        pub struct Delete {
+            pub(crate) object: IdOrNestedObject<Tombstone>,
+        }
+
+        #[derive(Clone)]
+        pub enum AnnouncableActivities {
+            Vote(Vote),
+            Delete(Delete),
+        }
+
+        fn main() {}
+    ))
+    .check(|_g| {})
+}

--- a/crates/paralegal-policy/tests/entrypoint-generics.rs
+++ b/crates/paralegal-policy/tests/entrypoint-generics.rs
@@ -68,6 +68,43 @@ fn default_method() -> Result<()> {
         fn actual_sink<T>(t: T) {}
 
         trait Snk {
+            fn sink(&self, t: usize) {
+                actual_sink(t)
+            }
+        }
+
+        struct Wrap<T>(T);
+
+        impl<T: Src> Wrap<T> {
+            #[paralegal::analyze]
+            fn main<S: Snk>(&self, s: &S) {
+                s.sink(self.0.source())
+            }
+        }
+    ))?;
+
+    test.run(simple_policy)
+}
+
+#[test]
+#[ignore = "Default methods with generics don't resolve properly. See https://github.com/brownsys/paralegal/issues/152"]
+fn default_method_with_generic() -> Result<()> {
+    let test = Test::new(stringify!(
+        #[paralegal::marker(source, return)]
+        fn actual_source() -> usize {
+            0
+        }
+
+        trait Src {
+            fn source(&self) -> usize {
+                actual_source()
+            }
+        }
+
+        #[paralegal::marker(sink, arguments = [0])]
+        fn actual_sink<T>(t: T) {}
+
+        trait Snk {
             fn sink<T>(&self, t: T) {
                 actual_sink(t)
             }

--- a/crates/paralegal-policy/tests/helpers/mod.rs
+++ b/crates/paralegal-policy/tests/helpers/mod.rs
@@ -8,7 +8,7 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
     sync::Arc,
-    time::SystemTime,
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use anyhow::anyhow;
@@ -34,14 +34,16 @@ lazy_static::lazy_static! {
 
 fn temporary_directory(to_hash: &impl Hash) -> Result<PathBuf> {
     let tmpdir = env::temp_dir();
-    let secs = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?;
     let mut hasher = DefaultHasher::new();
-    secs.hash(&mut hasher);
     to_hash.hash(&mut hasher);
+    let t = SystemTime::now().duration_since(UNIX_EPOCH)?;
+    t.hash(&mut hasher);
     let hash = hasher.finish();
     let short_hash = hash % 0x1_000_000;
     let path = tmpdir.join(format!("test-crate-{short_hash:06x}"));
-    fs::create_dir(&path)?;
+    if !path.exists() {
+        fs::create_dir(&path)?;
+    }
     Ok(path)
 }
 
@@ -70,6 +72,16 @@ impl Test {
     pub fn new(code: impl Into<String>) -> Result<Self> {
         let code = code.into();
         let tempdir = temporary_directory(&code)?;
+        for entry in fs::read_dir(&tempdir)? {
+            let f = entry?;
+            let typ = f.file_type()?;
+            if typ.is_dir() {
+                fs::remove_dir_all(f.path())?;
+            } else if typ.is_file() {
+                fs::remove_file(f.path())?;
+            }
+        }
+        println!("Running in {}", tempdir.display());
         Ok(Self {
             code,
             external_ann_file_name: tempdir.join("external_annotations.toml"),

--- a/crates/paralegal-policy/tests/misc_async.rs
+++ b/crates/paralegal-policy/tests/misc_async.rs
@@ -55,3 +55,20 @@ on_argument = [1]
         Ok(())
     })
 }
+
+#[test]
+#[ignore = "https://github.com/brownsys/paralegal/issues/159"]
+fn oneshot_channel() -> Result<()> {
+    let mut test = Test::new(stringify!(
+        #[paralegal::analyze]
+        async fn main() {
+            let (_, receiver) = tokio::sync::oneshot::channel();
+
+            receiver.await.unwrap()
+        }
+    ))?;
+
+    test.with_dep(["tokio", "--features", "sync"]);
+
+    test.run(|_ctx| Ok(()))
+}

--- a/crates/paralegal-spdg/src/lib.rs
+++ b/crates/paralegal-spdg/src/lib.rs
@@ -830,7 +830,7 @@ pub struct SPDG {
     pub statistics: SPDGStats,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, Default)]
 /// Statistics about the code that produced an SPDG
 pub struct SPDGStats {
     /// The number of unique lines of code we generated a PDG for. This means


### PR DESCRIPTION
## What Changed?

These are changes and fixes from the `cross-crate` branch that are independent of cross crate analysis itself.

- Factor the local analysis from `construct.rs` into its own module (`local_analysis.rs`).
- Factor out the function approximations into `approximations.rs`
- Additional test cases
- Full caching for child graphs independent of call strings
- Removal of `FnResolution`, instead expecting `Instance` everywhere.

## Why Does It Need To?

Expands the test suite and lines up test cases for as-yet-unfixed issues. Makes `construct.rs` more readable and navigable. 

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [ ] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [x] Documentation in Notion has been updated
- [x] Tests for new behaviors are provided
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.