### PR TITLE
Argument connection bug

### DIFF
--- a/crates/flowistry_pdg_construction/src/mutation.rs
+++ b/crates/flowistry_pdg_construction/src/mutation.rs
@@ -74,7 +74,7 @@ where
 /// [Self::Unspecified] mean do both.
 ///
 /// This has no effect on any statements or terminators besides function calls.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum Time {
     Unspecified,
     Before,
@@ -307,6 +307,11 @@ where
         location: Location,
         destination: Place<'tcx>,
     ) {
+        debug!(
+            "Combining args for location {location:?} at time {:?}. Arg places are {:?}",
+            self.time, arg_places
+        );
+
         let arg_place_inputs = arg_places
             .iter()
             .copied()

--- a/crates/paralegal-flow/src/test_utils.rs
+++ b/crates/paralegal-flow/src/test_utils.rs
@@ -265,6 +265,10 @@ impl InlineTestBuilder {
                 let tcx = result.tcx;
                 let memo = discover::CollectingVisitor::new(tcx, args, Stats::default());
                 let (pdg, _) = memo.run().unwrap();
+                if args.dbg().dump_spdg() {
+                    let out = std::fs::File::create("call-only-flow.gv").unwrap();
+                    paralegal_spdg::dot::dump(&pdg, out).unwrap();
+                }
                 let graph = PreFrg::from_description(pdg);
                 f(graph)
             })

--- a/crates/paralegal-flow/src/test_utils.rs
+++ b/crates/paralegal-flow/src/test_utils.rs
@@ -257,6 +257,8 @@ impl InlineTestBuilder {
 
         args.setup_logging();
 
+        let name = self.ctrl_name.clone();
+
         rustc_utils::test_utils::CompileBuilder::new(&self.input)
             .with_args(EXTRA_RUSTC_ARGS.iter().copied().map(ToOwned::to_owned))
             .compile(move |result| {
@@ -266,7 +268,7 @@ impl InlineTestBuilder {
                 let memo = discover::CollectingVisitor::new(tcx, args, Stats::default());
                 let (pdg, _) = memo.run().unwrap();
                 if args.dbg().dump_spdg() {
-                    let out = std::fs::File::create("call-only-flow.gv").unwrap();
+                    let out = std::fs::File::create(format!("{name}.cof.gv")).unwrap();
                     paralegal_spdg::dot::dump(&pdg, out).unwrap();
                 }
                 let graph = PreFrg::from_description(pdg);
@@ -660,7 +662,7 @@ impl<'g> NodeRefs<'g> {
             .copied()
             .flat_map(|n| {
                 graph
-                    .edges(n)
+                    .edges_directed(n, direction)
                     .filter(|e| match edge_selection {
                         EdgeSelection::Data => e.weight().is_data(),
                         EdgeSelection::Control => e.weight().is_control(),

--- a/crates/paralegal-flow/tests/function-calls.rs
+++ b/crates/paralegal-flow/tests/function-calls.rs
@@ -1,19 +1,17 @@
 #![feature(rustc_private)]
-#[macro_use]
-extern crate lazy_static;
 
 use paralegal_flow::test_utils::*;
 use paralegal_spdg::Identifier;
 
 #[test]
-fn argument_return_connection() {
+fn argument_return_connection_with_field() {
     let mut test = InlineTestBuilder::new(stringify!(
         struct T {
             a: i32,
         }
 
         #[paralegal_flow::marker(target, return)]
-        fn function(t: T) -> T {
+        fn function<T>(t: T) -> T {
             t
         }
 
@@ -27,6 +25,32 @@ fn argument_return_connection() {
         let target = ctrl.marked(Identifier::new_intern("target"));
         let direct = target.predecessors_data();
         let indirect = direct.predecessors_data();
-        assert!(&direct.overlaps(&indirect));
+        assert_ne!(direct.nodes().len(), 0);
+        assert_ne!(indirect.nodes().len(), 0);
+        assert!(!direct.overlaps(&indirect));
+    });
+}
+
+#[test]
+fn argument_return_connection_non_field() {
+    let mut test = InlineTestBuilder::new(stringify!(
+        #[paralegal_flow::marker(target, return)]
+        fn function<T>(t: T) -> T {
+            t
+        }
+
+        fn main() {
+            let t = 1_usize;
+            let t2 = function(t);
+        }
+    ));
+    //test.with_extra_args(["--dump".to_string(), "spdg".to_string()]);
+    test.check_ctrl(|ctrl| {
+        let target = ctrl.marked(Identifier::new_intern("target"));
+        let direct = target.predecessors_data();
+        let indirect = direct.predecessors_data();
+        assert_ne!(direct.nodes().len(), 0);
+        assert_ne!(indirect.nodes().len(), 0);
+        assert!(!&direct.overlaps(&indirect));
     });
 }

--- a/crates/paralegal-flow/tests/function-calls.rs
+++ b/crates/paralegal-flow/tests/function-calls.rs
@@ -1,0 +1,26 @@
+#![feature(rustc_private)]
+#[macro_use]
+extern crate lazy_static;
+
+use paralegal_flow::test_utils::*;
+
+#[test]
+fn argument_return_connection() {
+    let mut test = InlineTestBuilder::new(stringify!(
+        struct T {
+            a: i32,
+        }
+
+        #[paralegal_flow::marker(noinline)]
+        fn function(t: T) -> T {
+            t
+        }
+
+        fn main() {
+            let t = T { a: 1 };
+            let t2 = function(t);
+        }
+    ));
+    test.with_extra_args(["--dump".to_string(), "spdg".to_string()]);
+    test.check_ctrl(|ctrl| {});
+}

--- a/crates/paralegal-flow/tests/function-calls.rs
+++ b/crates/paralegal-flow/tests/function-calls.rs
@@ -3,6 +3,7 @@
 extern crate lazy_static;
 
 use paralegal_flow::test_utils::*;
+use paralegal_spdg::Identifier;
 
 #[test]
 fn argument_return_connection() {
@@ -11,7 +12,7 @@ fn argument_return_connection() {
             a: i32,
         }
 
-        #[paralegal_flow::marker(noinline)]
+        #[paralegal_flow::marker(target, return)]
         fn function(t: T) -> T {
             t
         }
@@ -21,6 +22,11 @@ fn argument_return_connection() {
             let t2 = function(t);
         }
     ));
-    test.with_extra_args(["--dump".to_string(), "spdg".to_string()]);
-    test.check_ctrl(|ctrl| {});
+    //test.with_extra_args(["--dump".to_string(), "spdg".to_string()]);
+    test.check_ctrl(|ctrl| {
+        let target = ctrl.marked(Identifier::new_intern("target"));
+        let direct = target.predecessors_data();
+        let indirect = direct.predecessors_data();
+        assert!(&direct.overlaps(&indirect));
+    });
 }


### PR DESCRIPTION
## What Changed?

Fixes a bug where if a struct with individually tracked fields is input to an unanalyzed function, edges are inserted from the field nodes before to the return value.

## Why Does It Need To?

Fewer bugs 😛 

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [ ] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [ ] Documentation in Notion has been updated
- [x] Tests for new behaviors are provided
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.