### PR TITLE
Makes deserialization of config and external annotation files strict

### DIFF
--- a/crates/paralegal-flow/src/ann/mod.rs
+++ b/crates/paralegal-flow/src/ann/mod.rs
@@ -34,6 +34,7 @@ use crate::{discover::AttrMatchT, sym_vec, utils::MetaItemMatch};
 #[derive(
     PartialEq, Eq, Debug, Clone, Deserialize, Serialize, strum::EnumIs, Encodable, Decodable,
 )]
+#[serde(deny_unknown_fields)]
 pub enum Annotation {
     Marker(MarkerAnnotation),
     OType(#[serde(with = "rustc_proxies::DefId")] TypeId),
@@ -71,6 +72,7 @@ pub type VerificationHash = u128;
 #[derive(
     PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Serialize, Deserialize, Encodable, Decodable,
 )]
+#[serde(deny_unknown_fields)]
 pub struct ExceptionAnnotation {
     /// The value of the verification hash we found in the annotation. Is `None`
     /// if there was no verification hash in the annotation.

--- a/crates/paralegal-flow/src/args.rs
+++ b/crates/paralegal-flow/src/args.rs
@@ -664,6 +664,7 @@ impl DumpArgs {
 
 /// Dependency specific configuration
 #[derive(serde::Serialize, serde::Deserialize, Default, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct DepConfig {
     #[serde(default, alias = "rust-features")]
     /// Additional rust features to enable
@@ -672,6 +673,7 @@ pub struct DepConfig {
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 #[serde(tag = "mode", rename_all = "kebab-case")]
+#[serde(deny_unknown_fields)]
 pub enum Stub {
     #[serde(rename_all = "kebab-case")]
     /// Replaces the result of a call to a higher-order function with a call to
@@ -685,6 +687,7 @@ pub enum Stub {
 /// Additional configuration for the build process/rustc
 #[derive(serde::Deserialize, serde::Serialize, Default, Debug)]
 #[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields)]
 pub struct BuildConfig {
     /// Dependency specific configuration
     #[serde(default)]


### PR DESCRIPTION
## What Changed?

Denies unknown fields for parsing of build config and external annotation files

## Why Does It Need To?

Reduces the chances of misconfiguration by a user, for example from a typo in in the external annotation files.

## Checklist

- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [ ] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [ ] Documentation in Notion has been updated
- [ ] Tests for new behaviors are provided
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.