### PR TITLE
Merge marker assignment to PDG assembly

### DIFF
--- a/crates/flowistry_pdg/src/lib.rs
+++ b/crates/flowistry_pdg/src/lib.rs
@@ -18,3 +18,31 @@ pub mod rustc_portable;
 pub mod rustc_proxies;
 
 pub use pdg::*;
+
+pub mod utils {
+    use std::fmt;
+
+    /// Write all elements from `it` into the formatter `fmt` using `f`, separating
+    /// them with `sep`
+    pub fn write_sep<
+        E,
+        I: IntoIterator<Item = E>,
+        F: FnMut(E, &mut fmt::Formatter<'_>) -> fmt::Result,
+    >(
+        fmt: &mut fmt::Formatter<'_>,
+        sep: &str,
+        it: I,
+        mut f: F,
+    ) -> fmt::Result {
+        let mut first = true;
+        for e in it {
+            if first {
+                first = false;
+            } else {
+                fmt.write_str(sep)?;
+            }
+            f(e, fmt)?;
+        }
+        Ok(())
+    }
+}

--- a/crates/flowistry_pdg_construction/src/call_tree_visit.rs
+++ b/crates/flowistry_pdg_construction/src/call_tree_visit.rs
@@ -51,6 +51,10 @@ impl<'tcx, 'c, K: Clone> VisitDriver<'tcx, 'c, K> {
         self.current.1.as_ref().borrow()
     }
 
+    pub fn current_graph_as_rc(&self) -> Rc<Cow<'c, PartialGraph<'tcx, K>>> {
+        self.current.1.clone()
+    }
+
     pub fn globalize_location(&mut self, location: &OneHopLocation) -> CallString {
         self.with_pushed_stack(
             GlobalLocation {

--- a/crates/flowistry_pdg_construction/src/call_tree_visit.rs
+++ b/crates/flowistry_pdg_construction/src/call_tree_visit.rs
@@ -16,7 +16,7 @@ use flowistry_pdg::{CallString, GlobalLocation, RichLocation};
 use rustc_middle::{mir::Location, ty::Instance};
 
 use crate::{
-    graph::{DepEdge, DepNode, Node, OneHopLocation, PartialGraph},
+    graph::{DepEdge, DepNode, GraphConnectionPoint, Node, OneHopLocation, PartialGraph},
     MemoPdgConstructor,
 };
 
@@ -114,7 +114,7 @@ pub trait Visitor<'tcx, K: Hash + Eq + Clone> {
         loc: Location,
         inst: Instance<'tcx>,
         k: &K,
-        _ctrl_inputs: &[(Node, DepEdge<OneHopLocation>)],
+        _ctrl_inputs: &[GraphConnectionPoint<'tcx>],
     ) {
         vis.visit_inlined_call(self, loc, inst, k);
     }

--- a/crates/flowistry_pdg_construction/src/call_tree_visit.rs
+++ b/crates/flowistry_pdg_construction/src/call_tree_visit.rs
@@ -153,7 +153,7 @@ impl<'tcx, 'c, K: Clone + Hash + Eq> VisitDriver<'tcx, 'c, K> {
             let parent = self.graph_stack[self.graph_stack.len() - 2].1.clone();
             let cloc = self.call_stack().last().unwrap().location;
             for (node, info) in parent.iter_nodes() {
-                if info.at.in_child.map_or(false, |(d, _)| d == graph.def_id)
+                if info.at.in_child.is_some_and(|(d, _)| d == graph.def_id)
                     && info.at.location == cloc
                 {
                     let is_at_start = info.at.in_child.unwrap().1;
@@ -170,8 +170,7 @@ impl<'tcx, 'c, K: Clone + Hash + Eq> VisitDriver<'tcx, 'c, K> {
                                 }
                                 .into(),
                             )
-                            .unwrap()
-                            .into(),
+                            .unwrap(),
                         is_at_start,
                     );
                 }

--- a/crates/flowistry_pdg_construction/src/call_tree_visit.rs
+++ b/crates/flowistry_pdg_construction/src/call_tree_visit.rs
@@ -23,7 +23,7 @@ use crate::{
 pub struct VisitDriver<'tcx, 'c, K: Clone> {
     memo: &'c MemoPdgConstructor<'tcx, K>,
     call_string_stack: Vec<GlobalLocation>,
-    current: (Instance<'tcx>, Rc<Cow<'c, PartialGraph<'tcx, K>>>),
+    graph_stack: Vec<(Instance<'tcx>, Rc<Cow<'c, PartialGraph<'tcx, K>>>)>,
     _k: K,
 }
 
@@ -43,16 +43,16 @@ impl<'tcx, 'c, K: Clone> VisitDriver<'tcx, 'c, K> {
     }
 
     pub fn current_function(&self) -> Instance<'tcx> {
-        self.current.0
+        self.graph_stack.last().unwrap().0
     }
 
     pub fn current_graph(&self) -> &PartialGraph<'tcx, K> {
         use std::borrow::Borrow;
-        self.current.1.as_ref().borrow()
+        self.graph_stack.last().unwrap().1.as_ref().borrow()
     }
 
     pub fn current_graph_as_rc(&self) -> Rc<Cow<'c, PartialGraph<'tcx, K>>> {
-        self.current.1.clone()
+        self.graph_stack.last().unwrap().1.clone()
     }
 
     pub fn globalize_location(&mut self, location: &OneHopLocation) -> CallString {
@@ -100,6 +100,17 @@ pub trait Visitor<'tcx, K: Hash + Eq + Clone> {
     ) {
     }
 
+    /// These nodes between the current graph and the caller should be
+    /// considered the same.
+    fn visit_parent_connection(
+        &mut self,
+        _vis: &mut VisitDriver<'tcx, '_, K>,
+        _in_caller: Node,
+        _in_this: Node,
+        _is_at_start: bool,
+    ) {
+    }
+
     fn visit_node(
         &mut self,
         _vis: &mut VisitDriver<'tcx, '_, K>,
@@ -129,7 +140,7 @@ impl<'tcx, 'c, K: Clone + Hash + Eq> VisitDriver<'tcx, 'c, K> {
         Self {
             memo,
             call_string_stack: Vec::new(),
-            current: (start, Rc::new(g)),
+            graph_stack: vec![(start, Rc::new(g))],
             _k: k,
         }
     }
@@ -138,6 +149,34 @@ impl<'tcx, 'c, K: Clone + Hash + Eq> VisitDriver<'tcx, 'c, K> {
         vis: &mut V,
         graph: &PartialGraph<'tcx, K>,
     ) {
+        if self.graph_stack.len() > 1 {
+            let parent = self.graph_stack[self.graph_stack.len() - 2].1.clone();
+            let cloc = self.call_stack().last().unwrap().location;
+            for (node, info) in parent.iter_nodes() {
+                if info.at.in_child.map_or(false, |(d, _)| d == graph.def_id)
+                    && info.at.location == cloc
+                {
+                    let is_at_start = info.at.in_child.unwrap().1;
+                    vis.visit_parent_connection(
+                        self,
+                        node,
+                        graph
+                            .get_node(
+                                info.place,
+                                if is_at_start {
+                                    RichLocation::Start
+                                } else {
+                                    RichLocation::End
+                                }
+                                .into(),
+                            )
+                            .unwrap()
+                            .into(),
+                        is_at_start,
+                    );
+                }
+            }
+        }
         for (node, info) in graph.iter_nodes() {
             vis.visit_node(self, node, info);
         }
@@ -162,22 +201,19 @@ impl<'tcx, 'c, K: Clone + Hash + Eq> VisitDriver<'tcx, 'c, K> {
                 location: loc.into(),
             },
             |slf| {
-                let old = std::mem::replace(
-                    &mut slf.current,
-                    (
-                        inst,
-                        Rc::new(slf.memo.construct_for((inst, k.clone())).unwrap()),
-                    ),
-                );
-                let graph: Rc<_> = slf.current.1.clone();
+                slf.graph_stack.push((
+                    inst,
+                    Rc::new(slf.memo.construct_for((inst, k.clone())).unwrap()),
+                ));
+                let graph: Rc<_> = slf.current_graph_as_rc();
                 vis.visit_partial_graph(slf, &graph);
-                slf.current = old;
+                slf.graph_stack.pop();
             },
         );
     }
 
     pub fn start<V: Visitor<'tcx, K> + ?Sized>(&mut self, vis: &mut V) {
-        let g = self.current.1.clone();
+        let g = self.current_graph_as_rc();
         vis.visit_partial_graph(self, &g);
     }
 }

--- a/crates/flowistry_pdg_construction/src/call_tree_visit.rs
+++ b/crates/flowistry_pdg_construction/src/call_tree_visit.rs
@@ -25,6 +25,7 @@ pub struct VisitDriver<'tcx, 'c, K: Clone> {
     call_string_stack: Vec<GlobalLocation>,
     graph_stack: Vec<(Instance<'tcx>, Rc<Cow<'c, PartialGraph<'tcx, K>>>)>,
     _k: K,
+    ctrl_inputs: Option<(usize, Box<[GraphConnectionPoint<'tcx>]>)>,
 }
 
 impl<'tcx, 'c, K: Clone> VisitDriver<'tcx, 'c, K> {
@@ -111,6 +112,21 @@ pub trait Visitor<'tcx, K: Hash + Eq + Clone> {
     ) {
     }
 
+    /// The index is which level in the call stack this control edge comes from,
+    /// since they can sometimes skip a function.
+    ///
+    /// For implementation reasons, this index is negative, e.g. from the back
+    /// of the call stack.
+    fn visit_ctrl_edge(
+        &mut self,
+        _vis: &mut VisitDriver<'tcx, '_, K>,
+        _index: usize,
+        _src: Node,
+        _dst: Node,
+        _kind: &DepEdge<OneHopLocation>,
+    ) {
+    }
+
     fn visit_node(
         &mut self,
         _vis: &mut VisitDriver<'tcx, '_, K>,
@@ -125,9 +141,9 @@ pub trait Visitor<'tcx, K: Hash + Eq + Clone> {
         loc: Location,
         inst: Instance<'tcx>,
         k: &K,
-        _ctrl_inputs: &[GraphConnectionPoint<'tcx>],
+        ctrl_inputs: &[GraphConnectionPoint<'tcx>],
     ) {
-        vis.visit_inlined_call(self, loc, inst, k);
+        vis.visit_inlined_call(self, loc, inst, k, ctrl_inputs);
     }
 }
 
@@ -142,8 +158,10 @@ impl<'tcx, 'c, K: Clone + Hash + Eq> VisitDriver<'tcx, 'c, K> {
             call_string_stack: Vec::new(),
             graph_stack: vec![(start, Rc::new(g))],
             _k: k,
+            ctrl_inputs: None,
         }
     }
+
     pub fn visit_partial_graph<V: Visitor<'tcx, K> + ?Sized>(
         &mut self,
         vis: &mut V,
@@ -182,6 +200,25 @@ impl<'tcx, 'c, K: Clone + Hash + Eq> VisitDriver<'tcx, 'c, K> {
         for (src, dst, kind) in graph.iter_edges() {
             vis.visit_edge(self, src, dst, kind);
         }
+        // We annoyingly "need" to use a negative index here, because async
+        // handling messes with the length of our call stack, making the
+        // positive indices on them go out of sync.
+
+        if let Some((idx, ctrl_in)) = self.ctrl_inputs.take() {
+            for (node, _) in graph.iter_nodes() {
+                if !graph
+                    .raw()
+                    .edges_directed(node, petgraph::Direction::Incoming)
+                    .any(|e| e.weight().is_control())
+                {
+                    for (src, edge) in ctrl_in.iter() {
+                        vis.visit_ctrl_edge(self, idx, *src, node, edge);
+                    }
+                }
+            }
+            self.ctrl_inputs = Some((idx, ctrl_in));
+        }
+
         for (loc, inst, k, ctrl_inputs) in &graph.inlined_calls {
             vis.visit_inlined_call(self, *loc, *inst, k, ctrl_inputs);
         }
@@ -193,6 +230,7 @@ impl<'tcx, 'c, K: Clone + Hash + Eq> VisitDriver<'tcx, 'c, K> {
         loc: Location,
         inst: Instance<'tcx>,
         k: &K,
+        ctrl_inputs: &[GraphConnectionPoint<'tcx>],
     ) {
         self.with_pushed_stack(
             GlobalLocation {
@@ -204,9 +242,17 @@ impl<'tcx, 'c, K: Clone + Hash + Eq> VisitDriver<'tcx, 'c, K> {
                     inst,
                     Rc::new(slf.memo.construct_for((inst, k.clone())).unwrap()),
                 ));
+                let old_ctrl_inputs = std::mem::replace(
+                    &mut slf.ctrl_inputs,
+                    Some((
+                        slf.graph_stack.len() - 1,
+                        ctrl_inputs.to_vec().into_boxed_slice(),
+                    )),
+                );
                 let graph: Rc<_> = slf.current_graph_as_rc();
                 vis.visit_partial_graph(slf, &graph);
                 slf.graph_stack.pop();
+                slf.ctrl_inputs = old_ctrl_inputs;
             },
         );
     }

--- a/crates/flowistry_pdg_construction/src/call_tree_visit.rs
+++ b/crates/flowistry_pdg_construction/src/call_tree_visit.rs
@@ -25,7 +25,7 @@ pub struct VisitDriver<'tcx, 'c, K: Clone> {
     call_string_stack: Vec<GlobalLocation>,
     graph_stack: Vec<(Instance<'tcx>, Rc<Cow<'c, PartialGraph<'tcx, K>>>)>,
     _k: K,
-    ctrl_inputs: Option<(usize, Box<[GraphConnectionPoint<'tcx>]>)>,
+    ctrl_inputs: Option<(usize, Box<[GraphConnectionPoint<'tcx, CallString>]>)>,
 }
 
 impl<'tcx, 'c, K: Clone> VisitDriver<'tcx, 'c, K> {
@@ -120,7 +120,7 @@ pub trait Visitor<'tcx, K: Hash + Eq + Clone> {
         _index: usize,
         _src: Node,
         _dst: Node,
-        _kind: &DepEdge<OneHopLocation>,
+        _kind: &DepEdge<CallString>,
     ) {
     }
 
@@ -138,7 +138,7 @@ pub trait Visitor<'tcx, K: Hash + Eq + Clone> {
         loc: Location,
         inst: Instance<'tcx>,
         k: &K,
-        ctrl_inputs: &[GraphConnectionPoint<'tcx>],
+        ctrl_inputs: Box<[GraphConnectionPoint<'tcx, CallString>]>,
     ) {
         vis.visit_inlined_call(self, loc, inst, k, ctrl_inputs);
     }
@@ -217,7 +217,11 @@ impl<'tcx, 'c, K: Clone + Hash + Eq> VisitDriver<'tcx, 'c, K> {
         }
 
         for (loc, inst, k, ctrl_inputs) in &graph.inlined_calls {
-            vis.visit_inlined_call(self, *loc, *inst, k, ctrl_inputs);
+            let globalized_ctrl_input = ctrl_inputs
+                .iter()
+                .map(|(src, edge)| (*src, edge.map_at(|a| self.globalize_location(a))))
+                .collect();
+            vis.visit_inlined_call(self, *loc, *inst, k, globalized_ctrl_input);
         }
     }
 
@@ -227,16 +231,13 @@ impl<'tcx, 'c, K: Clone + Hash + Eq> VisitDriver<'tcx, 'c, K> {
         loc: Location,
         inst: Instance<'tcx>,
         k: &K,
-        ctrl_inputs: &[GraphConnectionPoint<'tcx>],
+        ctrl_inputs: Box<[GraphConnectionPoint<'tcx, CallString>]>,
     ) {
         let swap_ctrl_input = !ctrl_inputs.is_empty();
         let old_ctrl_inputs = if swap_ctrl_input {
             std::mem::replace(
                 &mut self.ctrl_inputs,
-                Some((
-                    self.graph_stack.len() - 1,
-                    ctrl_inputs.to_vec().into_boxed_slice(),
-                )),
+                Some((self.graph_stack.len() - 1, ctrl_inputs)),
             )
         } else {
             None

--- a/crates/flowistry_pdg_construction/src/call_tree_visit.rs
+++ b/crates/flowistry_pdg_construction/src/call_tree_visit.rs
@@ -16,7 +16,7 @@ use flowistry_pdg::{CallString, GlobalLocation, RichLocation};
 use rustc_middle::{mir::Location, ty::Instance};
 
 use crate::{
-    graph::{DepEdge, DepNode, OneHopLocation, PartialGraph},
+    graph::{DepEdge, DepNode, Node, OneHopLocation, PartialGraph},
     MemoPdgConstructor,
 };
 
@@ -94,8 +94,8 @@ pub trait Visitor<'tcx, K: Hash + Eq + Clone> {
     fn visit_edge(
         &mut self,
         _vis: &mut VisitDriver<'tcx, '_, K>,
-        _src: &DepNode<'tcx, OneHopLocation>,
-        _dst: &DepNode<'tcx, OneHopLocation>,
+        _src: Node,
+        _dst: Node,
         _kind: &DepEdge<OneHopLocation>,
     ) {
     }
@@ -103,6 +103,7 @@ pub trait Visitor<'tcx, K: Hash + Eq + Clone> {
     fn visit_node(
         &mut self,
         _vis: &mut VisitDriver<'tcx, '_, K>,
+        _k: Node,
         _node: &DepNode<'tcx, OneHopLocation>,
     ) {
     }
@@ -113,7 +114,7 @@ pub trait Visitor<'tcx, K: Hash + Eq + Clone> {
         loc: Location,
         inst: Instance<'tcx>,
         k: &K,
-        _ctrl_inputs: &[(DepNode<'tcx, OneHopLocation>, DepEdge<OneHopLocation>)],
+        _ctrl_inputs: &[(Node, DepEdge<OneHopLocation>)],
     ) {
         vis.visit_inlined_call(self, loc, inst, k);
     }
@@ -137,10 +138,10 @@ impl<'tcx, 'c, K: Clone + Hash + Eq> VisitDriver<'tcx, 'c, K> {
         vis: &mut V,
         graph: &PartialGraph<'tcx, K>,
     ) {
-        for node in &graph.nodes {
-            vis.visit_node(self, node);
+        for (node, info) in graph.iter_nodes() {
+            vis.visit_node(self, node, info);
         }
-        for (src, dst, kind) in &graph.edges {
+        for (src, dst, kind) in graph.iter_edges() {
             vis.visit_edge(self, src, dst, kind);
         }
         for (loc, inst, k, ctrl_inputs) in &graph.inlined_calls {

--- a/crates/flowistry_pdg_construction/src/call_tree_visit.rs
+++ b/crates/flowistry_pdg_construction/src/call_tree_visit.rs
@@ -109,11 +109,14 @@ pub trait Visitor<'tcx, K: Hash + Eq + Clone> {
     ) {
     }
 
+    /// Visit a control edge coming from one of the callers of this function.
+    /// This function is only called for destination nodes that do not already
+    /// have incoming control flow edges.
+    ///
+    /// Note that _src is located in a caller graph, identified by the index.
+    ///
     /// The index is which level in the call stack this control edge comes from,
     /// since they can sometimes skip a function.
-    ///
-    /// For implementation reasons, this index is negative, e.g. from the back
-    /// of the call stack.
     fn visit_ctrl_edge(
         &mut self,
         _vis: &mut VisitDriver<'tcx, '_, K>,
@@ -197,10 +200,8 @@ impl<'tcx, 'c, K: Clone + Hash + Eq> VisitDriver<'tcx, 'c, K> {
         for (src, dst, kind) in graph.iter_edges() {
             vis.visit_edge(self, src, dst, kind);
         }
-        // We annoyingly "need" to use a negative index here, because async
-        // handling messes with the length of our call stack, making the
-        // positive indices on them go out of sync.
 
+        // Handle incoming control edges.
         if let Some((idx, ctrl_in)) = self.ctrl_inputs.take() {
             for (node, _) in graph.iter_nodes() {
                 if !graph

--- a/crates/flowistry_pdg_construction/src/call_tree_visit.rs
+++ b/crates/flowistry_pdg_construction/src/call_tree_visit.rs
@@ -33,10 +33,7 @@ impl<'tcx, 'c, K: Clone> VisitDriver<'tcx, 'c, K> {
     where
         F: FnOnce(&mut Self) -> R,
     {
-        self.call_string_stack.push(location);
-        let result = f(self);
-        self.call_string_stack.pop();
-        result
+        with_pushed_stack(self, |s| &mut s.call_string_stack, location, f)
     }
 
     pub fn call_stack(&self) -> &[GlobalLocation] {
@@ -232,33 +229,61 @@ impl<'tcx, 'c, K: Clone + Hash + Eq> VisitDriver<'tcx, 'c, K> {
         k: &K,
         ctrl_inputs: &[GraphConnectionPoint<'tcx>],
     ) {
+        let swap_ctrl_input = !ctrl_inputs.is_empty();
+        let old_ctrl_inputs = if swap_ctrl_input {
+            std::mem::replace(
+                &mut self.ctrl_inputs,
+                Some((
+                    self.graph_stack.len() - 1,
+                    ctrl_inputs.to_vec().into_boxed_slice(),
+                )),
+            )
+        } else {
+            None
+        };
         self.with_pushed_stack(
             GlobalLocation {
                 function: self.current_function().def_id(),
                 location: loc.into(),
             },
             |slf| {
-                slf.graph_stack.push((
-                    inst,
-                    Rc::new(slf.memo.construct_for((inst, k.clone())).unwrap()),
-                ));
-                let old_ctrl_inputs = std::mem::replace(
-                    &mut slf.ctrl_inputs,
-                    Some((
-                        slf.graph_stack.len() - 1,
-                        ctrl_inputs.to_vec().into_boxed_slice(),
-                    )),
-                );
-                let graph: Rc<_> = slf.current_graph_as_rc();
-                vis.visit_partial_graph(slf, &graph);
-                slf.graph_stack.pop();
-                slf.ctrl_inputs = old_ctrl_inputs;
+                with_pushed_stack(
+                    slf,
+                    |s| &mut s.graph_stack,
+                    (
+                        inst,
+                        Rc::new(slf.memo.construct_for((inst, k.clone())).unwrap()),
+                    ),
+                    |slf| {
+                        let graph: Rc<_> = slf.current_graph_as_rc();
+                        vis.visit_partial_graph(slf, &graph);
+                    },
+                )
             },
         );
+        if swap_ctrl_input {
+            self.ctrl_inputs = old_ctrl_inputs;
+        }
     }
 
     pub fn start<V: Visitor<'tcx, K> + ?Sized>(&mut self, vis: &mut V) {
         let g = self.current_graph_as_rc();
         vis.visit_partial_graph(self, &g);
     }
+}
+
+fn with_pushed_stack<T, E, R>(
+    obj: &mut T,
+    access: impl Fn(&mut T) -> &mut Vec<E>,
+    elem: E,
+    inner: impl FnOnce(&mut T) -> R,
+) -> R {
+    let stack = access(obj);
+    stack.push(elem);
+    let len_before = stack.len();
+    let result = inner(obj);
+    let stack = access(obj);
+    assert_eq!(stack.len(), len_before);
+    stack.pop();
+    result
 }

--- a/crates/flowistry_pdg_construction/src/construct.rs
+++ b/crates/flowistry_pdg_construction/src/construct.rs
@@ -360,16 +360,19 @@ impl<'mir, 'tcx, K: Hash + Eq + Clone>
         location: Location,
     ) {
         if let TerminatorKind::Call { func, args, .. } = &terminator.kind {
-            if matches!(
-                results.analysis.determine_call_handling(
-                    location,
-                    Cow::Borrowed(func),
-                    Cow::Borrowed(args),
-                    terminator.source_info.span
-                ),
-                Some(CallHandling::Ready { .. })
-            ) {
-                return;
+            let handling = results.analysis.determine_call_handling(
+                location,
+                Cow::Borrowed(func),
+                Cow::Borrowed(args),
+                terminator.source_info.span,
+            );
+            match handling {
+                Some(CallHandling::Ready { .. }) | Some(CallHandling::ApproxAsyncSM(_)) => {
+                    // I'm not totally sure whether we need to call the
+                    // approximation handler again here
+                    return;
+                }
+                _ => (),
             }
         }
 
@@ -538,7 +541,7 @@ impl<'tcx, K: Hash + Eq + Clone> PartialGraph<'tcx, K> {
         //
         // PRECISION TODO: for a given child place, we only want to connect
         // the *last* nodes in the child function to the parent, not *all* of them.
-        trace!("CHILD -> PARENT EDGES:");
+        trace!("CHILD -> PARENT EDGES for {:?}:", child_graph.def_id);
         for (child_dst, kind) in child_graph.parentable_dsts() {
             let child_dst = child_dst.map_at(|b| bool_to_loc(*b));
             let child_place = child_dst.place;
@@ -558,17 +561,7 @@ impl<'tcx, K: Hash + Eq + Clone> PartialGraph<'tcx, K> {
                 );
             }
         }
-        // self.edges.extend(
-        //     constructor
-        //         .find_control_inputs(location)
-        //         .into_iter()
-        //         .flat_map(|(ctrl_src, edge)| {
-        //             child_graph
-        //                 .nodes
-        //                 .iter()
-        //                 .map(move |dest| (ctrl_src.clone(), dest.clone(), edge.clone()))
-        //         }),
-        // );
+        trace!("Call handling finished");
         true
     }
 

--- a/crates/flowistry_pdg_construction/src/construct.rs
+++ b/crates/flowistry_pdg_construction/src/construct.rs
@@ -24,7 +24,10 @@ use crate::{
     call_tree_visit::{self, VisitDriver},
     callback::DefaultCallback,
     calling_convention::PlaceTranslator,
-    graph::{DepEdge, DepGraph, DepNode, OneHopLocation, PartialGraph, SourceUse, TargetUse},
+    graph::{
+        DepEdge, DepGraph, DepNode, GraphConnectionPoint, Node, OneHopLocation, PartialGraph,
+        SourceUse, TargetUse,
+    },
     local_analysis::{CallHandling, InstructionState, LocalAnalysis},
     mutation::{ModularMutationVisitor, Mutation, Time},
     two_level_cache::TwoLevelCache,
@@ -482,13 +485,13 @@ impl<'tcx, K: Hash + Eq + Clone> PartialGraph<'tcx, K> {
                 return false;
             }
         };
-
-        self.inlined_calls.push((
-            location,
-            child_instance,
-            k,
-            constructor.find_control_inputs(location),
-        ));
+        let ctrl_inputs = constructor
+            .find_control_inputs(location)
+            .into_iter()
+            .map(|(place, loc, edge)| (self.get_node(place, loc).unwrap(), edge))
+            .collect();
+        self.inlined_calls
+            .push((location, child_instance, k, ctrl_inputs));
         let child_graph = child_descriptor.as_ref();
 
         trace!("Child graph has generics {:?}", child_descriptor.generics);
@@ -513,14 +516,17 @@ impl<'tcx, K: Hash + Eq + Clone> PartialGraph<'tcx, K> {
         trace!("PARENT -> CHILD EDGES:");
         for (child_src, _kind) in child_graph.parentable_srcs() {
             let child_src = child_src.map_at(|b| bool_to_loc(*b));
-            if let Some(translation) = translator.translate_to_parent(child_src.place) {
+            let child_place = child_src.place;
+            let child_node =
+                self.get_or_construct_node(child_place, child_src.at.clone(), || child_src);
+            if let Some(translation) = translator.translate_to_parent(child_place) {
                 self.register_mutation(
                     results,
                     state,
                     Inputs::Unresolved {
                         places: vec![(translation, None)],
                     },
-                    Either::Right(child_src),
+                    Either::Right(child_node),
                     location,
                     TargetUse::Assign,
                 );
@@ -535,12 +541,15 @@ impl<'tcx, K: Hash + Eq + Clone> PartialGraph<'tcx, K> {
         trace!("CHILD -> PARENT EDGES:");
         for (child_dst, kind) in child_graph.parentable_dsts() {
             let child_dst = child_dst.map_at(|b| bool_to_loc(*b));
-            if let Some(parent_place) = translator.translate_to_parent(child_dst.place) {
+            let child_place = child_dst.place;
+            let child_node =
+                self.get_or_construct_node(child_place, child_dst.at.clone(), || child_dst);
+            if let Some(parent_place) = translator.translate_to_parent(child_place) {
                 self.register_mutation(
                     results,
                     state,
                     Inputs::Resolved {
-                        node: child_dst.clone(),
+                        node: child_node,
                         node_use: SourceUse::Operand,
                     },
                     Either::Left(parent_place),
@@ -568,7 +577,7 @@ impl<'tcx, K: Hash + Eq + Clone> PartialGraph<'tcx, K> {
         results: &LocalAnalysisResults<'tcx, '_, K>,
         state: &InstructionState<'tcx>,
         inputs: Inputs<'tcx>,
-        mutated: Either<Place<'tcx>, DepNode<'tcx, OneHopLocation>>,
+        mutated: Either<Place<'tcx>, Node>,
         location: Location,
         target_use: TargetUse,
     ) where
@@ -588,12 +597,13 @@ impl<'tcx, K: Hash + Eq + Clone> PartialGraph<'tcx, K> {
                     constructor
                         .find_data_inputs(state, input)
                         .into_iter()
-                        .map(move |input| {
-                            (
-                                input,
-                                input_use.map_or(SourceUse::Operand, SourceUse::Argument),
-                            )
-                        })
+                        .zip(std::iter::repeat(input_use))
+                })
+                .map(|(input, input_use)| {
+                    (
+                        self.insert_node(input),
+                        input_use.map_or(SourceUse::Operand, SourceUse::Argument),
+                    )
                 })
                 .collect::<Vec<_>>(),
             Inputs::Resolved { node_use, node } => vec![(node, node_use)],
@@ -606,31 +616,25 @@ impl<'tcx, K: Hash + Eq + Clone> PartialGraph<'tcx, K> {
                 .analysis
                 .find_outputs(place, location)
                 .into_iter()
-                .map(|t| t.1)
+                .map(|t| self.insert_node(t.1))
                 .collect(),
         };
         trace!("  Outputs: {outputs:?}");
-
-        for output in &outputs {
-            trace!("  Adding node {output}");
-            self.nodes.insert(output.clone());
-        }
 
         // Add data dependencies: data_input -> output
         for (data_input, source_use) in data_inputs {
             let data_edge = DepEdge::data(location.into(), source_use, target_use);
             for output in &outputs {
-                trace!("  Adding edge {data_input} -> {output}");
-                self.edges
-                    .insert((data_input.clone(), output.clone(), data_edge.clone()));
+                trace!("  Adding edge {data_input:?} -> {output:?}");
+                self.insert_edge(data_input.clone(), *output, data_edge.clone());
             }
         }
 
         // Add control dependencies: ctrl_input -> output
-        for (ctrl_input, edge) in &ctrl_inputs {
+        for (ctrl_input, loc, edge) in &ctrl_inputs {
+            let from = self.get_node(*ctrl_input, loc.clone()).unwrap();
             for output in &outputs {
-                self.edges
-                    .insert((ctrl_input.clone(), output.clone(), edge.clone()));
+                self.insert_edge(from, *output, edge.clone());
             }
         }
     }
@@ -648,7 +652,7 @@ enum Inputs<'tcx> {
         places: Vec<(Place<'tcx>, Option<u8>)>,
     },
     Resolved {
-        node: DepNode<'tcx, OneHopLocation>,
+        node: Node,
         node_use: SourceUse,
     },
 }
@@ -730,68 +734,6 @@ impl<'tcx> GraphAssembler<'tcx> {
     }
 }
 
-impl<'tcx, K: Hash + Eq + Clone> call_tree_visit::Visitor<'tcx, K> for GraphAssembler<'tcx> {
-    fn visit_inlined_call(
-        &mut self,
-        vis: &mut VisitDriver<'tcx, '_, K>,
-        loc: Location,
-        inst: Instance<'tcx>,
-        k: &K,
-        ctrl_inputs: &[(DepNode<'tcx, OneHopLocation>, DepEdge<OneHopLocation>)],
-    ) {
-        self.with_new_ctr_inputs(vis, ctrl_inputs, |slf, vis| {
-            vis.visit_inlined_call(slf, loc, inst, k)
-        })
-    }
-
-    fn visit_edge(
-        &mut self,
-        vis: &mut VisitDriver<'tcx, '_, K>,
-        src: &DepNode<'tcx, OneHopLocation>,
-        dst: &DepNode<'tcx, OneHopLocation>,
-        kind: &DepEdge<OneHopLocation>,
-    ) {
-        let src = globalize_node(vis, src);
-        let src_idx = self.add_node(src);
-        let dst = globalize_node(vis, dst);
-        let dst_idx = self.add_node(dst);
-        let new_kind = globalize_edge(vis, kind);
-        self.graph.add_edge(src_idx, dst_idx, new_kind);
-    }
-
-    fn visit_partial_graph(
-        &mut self,
-        vis: &mut VisitDriver<'tcx, '_, K>,
-        graph: &PartialGraph<'tcx, K>,
-    ) {
-        vis.visit_partial_graph(self, graph);
-
-        // This loop connects the control inputs that
-        // are incoming to the function to those nodes in the graph who have no
-        // control inputs yet.
-        //
-        // We do this here instead of in "visit_node", because that gets called
-        // before the "visit_edge" function, meaning we can't yet see the
-        // potential control inputs of the node. We could have the visitor use
-        // an opposite ordering, but that is counterintuitive to other potential
-        // users of the visitor.
-        for node in &graph.nodes {
-            let new_node = globalize_node(vis, node);
-            let node = self.add_node(new_node);
-
-            if !self
-                .graph
-                .edges_directed(node, petgraph::Direction::Incoming)
-                .any(|e| e.weight().is_control())
-            {
-                for (src, edge) in self.control_inputs.iter() {
-                    self.graph.add_edge(*src, node, edge.clone());
-                }
-            }
-        }
-    }
-}
-
 struct GraphSizeEstimator {
     nodes: usize,
     edges: usize,
@@ -842,8 +784,8 @@ impl<'tcx, K: Hash + Eq + Clone> call_tree_visit::Visitor<'tcx, K> for GraphSize
         vis: &mut VisitDriver<'tcx, '_, K>,
         graph: &PartialGraph<'tcx, K>,
     ) {
-        self.nodes += graph.nodes.len();
-        self.edges += graph.edges.len();
+        self.nodes += graph.node_count();
+        self.edges += graph.edge_count();
         self.functions += 1;
         let call_string = vis.call_stack();
         if self.max_call_string.len() < call_string.len() {
@@ -886,7 +828,8 @@ impl<'tcx, K: Clone + Hash + Eq> PartialGraph<'tcx, K> {
         let mut size_estimator = GraphSizeEstimator::new();
         visitor.start(&mut size_estimator);
         log::info!("Estimating a size of {}", size_estimator.format_size());
-        visitor.start(&mut assembler);
+        unimplemented!();
+        //visitor.start(&mut assembler);
         DepGraph {
             graph: assembler.graph,
         }
@@ -915,7 +858,8 @@ impl<'tcx, K: Clone + Hash + Eq> PartialGraph<'tcx, K> {
         visitor.start(&mut size_estimator);
         log::info!("Estimating a size of {}", size_estimator.format_size());
         visitor.with_pushed_stack(extra_global_location, |visitor| {
-            visitor.start(&mut assembler);
+            unimplemented!();
+            //visitor.start(&mut assembler);
         });
         DepGraph {
             graph: assembler.graph,

--- a/crates/flowistry_pdg_construction/src/construct.rs
+++ b/crates/flowistry_pdg_construction/src/construct.rs
@@ -706,16 +706,17 @@ impl<'tcx> GraphAssembler<'tcx> {
     fn with_new_ctr_inputs<'c, F, R, K: Clone>(
         &mut self,
         vis: &mut VisitDriver<'tcx, 'c, K>,
-        new_ctrl_inputs: &[(DepNode<'tcx, OneHopLocation>, DepEdge<OneHopLocation>)],
+        new_ctrl_inputs: &[GraphConnectionPoint<'tcx>],
         f: F,
     ) -> R
     where
         F: FnOnce(&mut Self, &mut VisitDriver<'tcx, 'c, K>) -> R,
     {
+        let g = vis.current_graph_as_rc();
         let new_ctrl_inputs: Box<[(NodeIndex, DepEdge<CallString>)]> = new_ctrl_inputs
             .iter()
             .map(|(src, edge)| {
-                let src = globalize_node(vis, src);
+                let src = globalize_node(vis, g.node_props(*src));
                 let src_idx = self.add_node(src);
                 let new_edge = globalize_edge(vis, edge);
                 (src_idx, new_edge)
@@ -733,6 +734,69 @@ impl<'tcx> GraphAssembler<'tcx> {
             self.control_inputs = old_ctrl_inputs;
         }
         r
+    }
+}
+
+impl<'tcx, K: Hash + Eq + Clone> call_tree_visit::Visitor<'tcx, K> for GraphAssembler<'tcx> {
+    fn visit_inlined_call(
+        &mut self,
+        vis: &mut VisitDriver<'tcx, '_, K>,
+        loc: Location,
+        inst: Instance<'tcx>,
+        k: &K,
+        ctrl_inputs: &[GraphConnectionPoint<'tcx>],
+    ) {
+        self.with_new_ctr_inputs(vis, ctrl_inputs, |slf, vis| {
+            vis.visit_inlined_call(slf, loc, inst, k)
+        })
+    }
+
+    fn visit_edge(
+        &mut self,
+        vis: &mut VisitDriver<'tcx, '_, K>,
+        src: Node,
+        dst: Node,
+        kind: &DepEdge<OneHopLocation>,
+    ) {
+        let g = vis.current_graph_as_rc();
+        let src = globalize_node(vis, g.node_props(src));
+        let src_idx = self.add_node(src);
+        let dst = globalize_node(vis, g.node_props(dst));
+        let dst_idx = self.add_node(dst);
+        let new_kind = globalize_edge(vis, kind);
+        self.graph.add_edge(src_idx, dst_idx, new_kind);
+    }
+
+    fn visit_partial_graph(
+        &mut self,
+        vis: &mut VisitDriver<'tcx, '_, K>,
+        graph: &PartialGraph<'tcx, K>,
+    ) {
+        vis.visit_partial_graph(self, graph);
+
+        // This loop connects the control inputs that
+        // are incoming to the function to those nodes in the graph who have no
+        // control inputs yet.
+        //
+        // We do this here instead of in "visit_node", because that gets called
+        // before the "visit_edge" function, meaning we can't yet see the
+        // potential control inputs of the node. We could have the visitor use
+        // an opposite ordering, but that is counterintuitive to other potential
+        // users of the visitor.
+        for (idx, node) in graph.iter_nodes() {
+            let new_node = globalize_node(vis, node);
+            let node = self.add_node(new_node);
+
+            if !self
+                .graph
+                .edges_directed(node, petgraph::Direction::Incoming)
+                .any(|e| e.weight().is_control())
+            {
+                for (src, edge) in self.control_inputs.iter() {
+                    self.graph.add_edge(*src, node, edge.clone());
+                }
+            }
+        }
     }
 }
 
@@ -830,8 +894,7 @@ impl<'tcx, K: Clone + Hash + Eq> PartialGraph<'tcx, K> {
         let mut size_estimator = GraphSizeEstimator::new();
         visitor.start(&mut size_estimator);
         log::info!("Estimating a size of {}", size_estimator.format_size());
-        unimplemented!();
-        //visitor.start(&mut assembler);
+        visitor.start(&mut assembler);
         DepGraph {
             graph: assembler.graph,
         }
@@ -860,8 +923,7 @@ impl<'tcx, K: Clone + Hash + Eq> PartialGraph<'tcx, K> {
         visitor.start(&mut size_estimator);
         log::info!("Estimating a size of {}", size_estimator.format_size());
         visitor.with_pushed_stack(extra_global_location, |visitor| {
-            unimplemented!();
-            //visitor.start(&mut assembler);
+            visitor.start(&mut assembler);
         });
         DepGraph {
             graph: assembler.graph,

--- a/crates/flowistry_pdg_construction/src/construct.rs
+++ b/crates/flowistry_pdg_construction/src/construct.rs
@@ -5,7 +5,7 @@ use flowistry::mir::FlowistryInput;
 use log::trace;
 use petgraph::graph::{DiGraph, NodeIndex};
 
-use flowistry_pdg::{CallString, GlobalLocation, RichLocation};
+use flowistry_pdg::{CallString, GlobalLocation};
 
 use df::ResultsVisitor;
 use rustc_errors::DiagMessage;
@@ -619,7 +619,7 @@ impl<'tcx, K: Hash + Eq + Clone> PartialGraph<'tcx, K> {
             let data_edge = DepEdge::data(location.into(), source_use, target_use);
             for output in &outputs {
                 trace!("  Adding edge {data_input:?} -> {output:?}");
-                self.insert_edge(data_input.clone(), *output, data_edge.clone());
+                self.insert_edge(data_input, *output, data_edge.clone());
             }
         }
 
@@ -776,7 +776,7 @@ impl<'tcx, K: Hash + Eq + Clone> call_tree_visit::Visitor<'tcx, K> for GraphAsse
         // potential control inputs of the node. We could have the visitor use
         // an opposite ordering, but that is counterintuitive to other potential
         // users of the visitor.
-        for (idx, node) in graph.iter_nodes() {
+        for (_, node) in graph.iter_nodes() {
             let new_node = globalize_node(vis, node);
             let node = self.add_node(new_node);
 

--- a/crates/flowistry_pdg_construction/src/construct.rs
+++ b/crates/flowistry_pdg_construction/src/construct.rs
@@ -632,7 +632,9 @@ impl<'tcx, K: Hash + Eq + Clone> PartialGraph<'tcx, K> {
 
         // Add control dependencies: ctrl_input -> output
         for (ctrl_input, loc, edge) in &ctrl_inputs {
-            let from = self.get_node(*ctrl_input, loc.clone()).unwrap();
+            let from = self.get_or_construct_node(*ctrl_input, loc.clone(), || {
+                constructor.make_dep_node(*ctrl_input, loc.location)
+            });
             for output in &outputs {
                 self.insert_edge(from, *output, edge.clone());
             }

--- a/crates/flowistry_pdg_construction/src/construct.rs
+++ b/crates/flowistry_pdg_construction/src/construct.rs
@@ -24,10 +24,7 @@ use crate::{
     call_tree_visit::{self, VisitDriver},
     callback::DefaultCallback,
     calling_convention::PlaceTranslator,
-    graph::{
-        DepEdge, DepGraph, DepNode, GraphConnectionPoint, Node, OneHopLocation, PartialGraph,
-        SourceUse, TargetUse,
-    },
+    graph::{DepEdge, DepGraph, DepNode, Node, OneHopLocation, PartialGraph, SourceUse, TargetUse},
     local_analysis::{CallHandling, InstructionState, LocalAnalysis},
     mutation::{ModularMutationVisitor, Mutation, Time},
     two_level_cache::TwoLevelCache,
@@ -687,63 +684,9 @@ impl<'tcx> GraphAssembler<'tcx> {
             .entry(node.clone())
             .or_insert_with(|| self.graph.add_node(node))
     }
-
-    /// Forwarding of control flow. It is sound to replace the control inputs
-    /// here rather than extend them because we are guaranteed that these new
-    /// nodes are connected to the old ctrl nodes, possibly transitively.
-    ///
-    /// Each node in our graph is either connected to a local control flow
-    /// node or to the ones coming from the parent, which is established by
-    /// the `visit_partial_graph` function. By induction all nodes, including
-    /// these control flow sources are connected to the old ctrl inputs.
-    fn with_new_ctr_inputs<'c, F, R, K: Clone>(
-        &mut self,
-        vis: &mut VisitDriver<'tcx, 'c, K>,
-        new_ctrl_inputs: &[GraphConnectionPoint<'tcx>],
-        f: F,
-    ) -> R
-    where
-        F: FnOnce(&mut Self, &mut VisitDriver<'tcx, 'c, K>) -> R,
-    {
-        let g = vis.current_graph_as_rc();
-        let new_ctrl_inputs: Box<[(NodeIndex, DepEdge<CallString>)]> = new_ctrl_inputs
-            .iter()
-            .map(|(src, edge)| {
-                let src = globalize_node(vis, g.node_props(*src));
-                let src_idx = self.add_node(src);
-                let new_edge = globalize_edge(vis, edge);
-                (src_idx, new_edge)
-            })
-            .collect();
-        // The last thing we need to ensure for that to hold is that the new
-        // ctrl inputs must not be empty. So if they are we leave the old one's intact.
-        let old_ctrl_inputs = if new_ctrl_inputs.is_empty() {
-            Box::new([])
-        } else {
-            std::mem::replace(&mut self.control_inputs, new_ctrl_inputs)
-        };
-        let r = f(self, vis);
-        if !old_ctrl_inputs.is_empty() {
-            self.control_inputs = old_ctrl_inputs;
-        }
-        r
-    }
 }
 
 impl<'tcx, K: Hash + Eq + Clone> call_tree_visit::Visitor<'tcx, K> for GraphAssembler<'tcx> {
-    fn visit_inlined_call(
-        &mut self,
-        vis: &mut VisitDriver<'tcx, '_, K>,
-        loc: Location,
-        inst: Instance<'tcx>,
-        k: &K,
-        ctrl_inputs: &[GraphConnectionPoint<'tcx>],
-    ) {
-        self.with_new_ctr_inputs(vis, ctrl_inputs, |slf, vis| {
-            vis.visit_inlined_call(slf, loc, inst, k)
-        })
-    }
-
     fn visit_edge(
         &mut self,
         vis: &mut VisitDriver<'tcx, '_, K>,

--- a/crates/flowistry_pdg_construction/src/graph.rs
+++ b/crates/flowistry_pdg_construction/src/graph.rs
@@ -350,6 +350,22 @@ impl<'tcx, K> PartialGraph<'tcx, K> {
         }
     }
 
+    pub fn iter_nodes(&self) -> impl Iterator<Item = &DepNode<'tcx, OneHopLocation>> + Clone {
+        self.nodes.iter()
+    }
+
+    pub fn iter_edges(
+        &self,
+    ) -> impl Iterator<
+        Item = &(
+            DepNode<'tcx, OneHopLocation>,
+            DepNode<'tcx, OneHopLocation>,
+            DepEdge<OneHopLocation>,
+        ),
+    > {
+        self.edges.iter()
+    }
+
     /// Returns the set of source places that the parent can access (write to)
     pub(crate) fn parentable_srcs<'a>(&'a self) -> FxHashSet<(DepNode<'tcx, bool>, Option<u8>)> {
         self.edges

--- a/crates/flowistry_pdg_construction/src/graph.rs
+++ b/crates/flowistry_pdg_construction/src/graph.rs
@@ -8,7 +8,11 @@ use std::{
 
 use flowistry_pdg::{CallString, RichLocation};
 use internment::Intern;
-use petgraph::{dot, graph::DiGraph};
+use petgraph::{
+    dot,
+    graph::{DiGraph, EdgeIndex},
+    visit::IntoNodeReferences,
+};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_hir::def_id::DefId;
@@ -306,8 +310,7 @@ impl DepGraph<'_> {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct Node(usize);
+pub type Node = petgraph::graph::NodeIndex;
 
 #[derive(Debug, Clone)]
 pub struct DepNodeProps {
@@ -319,20 +322,18 @@ pub struct DepNodeProps {
 
 #[derive(Debug, Clone)]
 pub struct PartialGraph<'tcx, K> {
-    pub(crate) nodes: FxHashMap<(Place<'tcx>, OneHopLocation), Node>,
-    pub(crate) assoc: Vec<(
-        DepNode<'tcx, OneHopLocation>,
-        Vec<(Node, DepEdge<OneHopLocation>)>,
-    )>,
-    pub(crate) generics: GenericArgsRef<'tcx>,
+    node_mapping: FxHashMap<(Place<'tcx>, OneHopLocation), Node>,
+    edge_mapping: FxHashMap<(Node, Node), EdgeIndex>,
+    graph: petgraph::Graph<DepNode<'tcx, OneHopLocation>, DepEdge<OneHopLocation>>,
     pub(crate) def_id: DefId,
     arg_count: usize,
+    pub(crate) generics: GenericArgsRef<'tcx>,
     local_decls: IndexVec<Local, LocalDecl<'tcx>>,
     pub(crate) k: K,
-    pub(crate) inlined_calls: Vec<(Location, Instance<'tcx>, K, Vec<GraphConnectionPoint>)>,
+    pub(crate) inlined_calls: Vec<(Location, Instance<'tcx>, K, Vec<GraphConnectionPoint<'tcx>>)>,
 }
 
-type GraphConnectionPoint = (Node, DepEdge<OneHopLocation>);
+pub type GraphConnectionPoint<'tcx> = (Node, DepEdge<OneHopLocation>);
 
 impl<'tcx, K> HasLocalDecls<'tcx> for PartialGraph<'tcx, K> {
     fn local_decls(&self) -> &LocalDecls<'tcx> {
@@ -349,8 +350,9 @@ impl<'tcx, K> PartialGraph<'tcx, K> {
         k: K,
     ) -> Self {
         Self {
-            nodes: Default::default(),
-            assoc: Default::default(),
+            node_mapping: Default::default(),
+            edge_mapping: Default::default(),
+            graph: petgraph::Graph::new(),
             generics,
             def_id,
             arg_count,
@@ -360,23 +362,56 @@ impl<'tcx, K> PartialGraph<'tcx, K> {
         }
     }
 
+    pub fn insert_node(&mut self, node: DepNode<'tcx, OneHopLocation>) -> Node {
+        self.get_or_construct_node(node.place, node.at.clone(), || node)
+    }
+
+    pub fn get_node(&self, place: Place<'tcx>, at: OneHopLocation) -> Option<Node> {
+        self.node_mapping.get(&(place, at)).copied()
+    }
+
+    pub fn get_or_construct_node(
+        &mut self,
+        place: Place<'tcx>,
+        at: OneHopLocation,
+        construct: impl FnOnce() -> DepNode<'tcx, OneHopLocation>,
+    ) -> Node {
+        if let Some(node) = self.get_node(place, at) {
+            node
+        } else {
+            let node = construct();
+            self.insert_node(node)
+        }
+    }
+
+    pub fn insert_edge(&mut self, source: Node, target: Node, edge: DepEdge<OneHopLocation>) {
+        let key = (source, target);
+        if let Some(prior) = self.edge_mapping.get(&key) {
+            let e = self.graph.edge_weight(*prior).unwrap();
+            assert_eq!(e, &edge);
+        } else {
+            let edge = self.graph.add_edge(source, target, edge);
+            self.edge_mapping.insert(key, edge);
+        }
+    }
+
     pub fn iter_nodes(
         &self,
     ) -> impl Iterator<Item = (Node, &DepNode<'tcx, OneHopLocation>)> + Clone {
-        self.assoc.iter().enumerate().map(|(n, v)| (Node(n), &v.0))
+        self.graph.node_references()
     }
 
     pub fn iter_edges<'a>(
         &'a self,
     ) -> impl Iterator<Item = (Node, Node, &'a DepEdge<OneHopLocation>)> + use<'tcx, 'a, K> {
-        self.assoc
-            .iter()
-            .enumerate()
-            .flat_map(|(from, v)| v.1.iter().map(move |(to, props)| (Node(from), *to, props)))
+        use petgraph::visit::EdgeRef;
+        self.graph
+            .edge_references()
+            .map(|r| (r.source(), r.target(), r.weight()))
     }
 
-    pub fn node_props(&self, Node(node): Node) -> &DepNode<'tcx, OneHopLocation> {
-        &self.assoc[node].0
+    pub fn node_props(&self, node: Node) -> &DepNode<'tcx, OneHopLocation> {
+        self.graph.node_weight(node).unwrap()
     }
 
     /// Returns the set of source places that the parent can access (write to)
@@ -412,6 +447,18 @@ impl<'tcx, K> PartialGraph<'tcx, K> {
                 Some((a, arg))
             })
             .collect()
+    }
+
+    pub fn node_count(&self) -> usize {
+        self.graph.node_count()
+    }
+
+    pub fn edge_count(&self) -> usize {
+        self.graph.edge_count()
+    }
+
+    pub fn raw(&self) -> &petgraph::Graph<DepNode<'tcx, OneHopLocation>, DepEdge<OneHopLocation>> {
+        &self.graph
     }
 }
 

--- a/crates/flowistry_pdg_construction/src/graph.rs
+++ b/crates/flowistry_pdg_construction/src/graph.rs
@@ -8,12 +8,7 @@ use std::{
 
 use flowistry_pdg::{CallString, RichLocation};
 use internment::Intern;
-use log::trace;
-use petgraph::{
-    dot,
-    graph::{DiGraph, EdgeIndex},
-    visit::IntoNodeReferences,
-};
+use petgraph::{dot, graph::DiGraph, visit::IntoNodeReferences};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_hir::def_id::DefId;

--- a/crates/flowistry_pdg_construction/src/graph.rs
+++ b/crates/flowistry_pdg_construction/src/graph.rs
@@ -348,6 +348,10 @@ impl<'tcx, K> PartialGraph<'tcx, K> {
         }
     }
 
+    pub fn def_id(&self) -> DefId {
+        self.def_id
+    }
+
     pub fn insert_node(&mut self, node: DepNode<'tcx, OneHopLocation>) -> Node {
         self.get_or_construct_node(node.place, node.at.clone(), || node)
     }

--- a/crates/flowistry_pdg_construction/src/graph.rs
+++ b/crates/flowistry_pdg_construction/src/graph.rs
@@ -10,7 +10,7 @@ use flowistry_pdg::{CallString, RichLocation};
 use internment::Intern;
 use petgraph::{dot, graph::DiGraph};
 
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_hir::def_id::DefId;
 use rustc_index::IndexVec;
 use rustc_middle::{
@@ -306,23 +306,33 @@ impl DepGraph<'_> {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct Node(usize);
+
+#[derive(Debug, Clone)]
+pub struct DepNodeProps {
+    key: Node,
+    is_split: bool,
+    place_pretty: Option<Intern<String>>,
+    span: Span,
+}
+
 #[derive(Debug, Clone)]
 pub struct PartialGraph<'tcx, K> {
-    pub(crate) nodes: FxHashSet<DepNode<'tcx, OneHopLocation>>,
-    pub(crate) edges: FxHashSet<(
+    pub(crate) nodes: FxHashMap<(Place<'tcx>, OneHopLocation), Node>,
+    pub(crate) assoc: Vec<(
         DepNode<'tcx, OneHopLocation>,
-        DepNode<'tcx, OneHopLocation>,
-        DepEdge<OneHopLocation>,
+        Vec<(Node, DepEdge<OneHopLocation>)>,
     )>,
     pub(crate) generics: GenericArgsRef<'tcx>,
     pub(crate) def_id: DefId,
     arg_count: usize,
     local_decls: IndexVec<Local, LocalDecl<'tcx>>,
     pub(crate) k: K,
-    pub(crate) inlined_calls: Vec<(Location, Instance<'tcx>, K, Vec<GraphConnectionPoint<'tcx>>)>,
+    pub(crate) inlined_calls: Vec<(Location, Instance<'tcx>, K, Vec<GraphConnectionPoint>)>,
 }
 
-type GraphConnectionPoint<'tcx> = (DepNode<'tcx, OneHopLocation>, DepEdge<OneHopLocation>);
+type GraphConnectionPoint = (Node, DepEdge<OneHopLocation>);
 
 impl<'tcx, K> HasLocalDecls<'tcx> for PartialGraph<'tcx, K> {
     fn local_decls(&self) -> &LocalDecls<'tcx> {
@@ -340,7 +350,7 @@ impl<'tcx, K> PartialGraph<'tcx, K> {
     ) -> Self {
         Self {
             nodes: Default::default(),
-            edges: Default::default(),
+            assoc: Default::default(),
             generics,
             def_id,
             arg_count,
@@ -350,28 +360,31 @@ impl<'tcx, K> PartialGraph<'tcx, K> {
         }
     }
 
-    pub fn iter_nodes(&self) -> impl Iterator<Item = &DepNode<'tcx, OneHopLocation>> + Clone {
-        self.nodes.iter()
+    pub fn iter_nodes(
+        &self,
+    ) -> impl Iterator<Item = (Node, &DepNode<'tcx, OneHopLocation>)> + Clone {
+        self.assoc.iter().enumerate().map(|(n, v)| (Node(n), &v.0))
     }
 
-    pub fn iter_edges(
-        &self,
-    ) -> impl Iterator<
-        Item = &(
-            DepNode<'tcx, OneHopLocation>,
-            DepNode<'tcx, OneHopLocation>,
-            DepEdge<OneHopLocation>,
-        ),
-    > {
-        self.edges.iter()
+    pub fn iter_edges<'a>(
+        &'a self,
+    ) -> impl Iterator<Item = (Node, Node, &'a DepEdge<OneHopLocation>)> + use<'tcx, 'a, K> {
+        self.assoc
+            .iter()
+            .enumerate()
+            .flat_map(|(from, v)| v.1.iter().map(move |(to, props)| (Node(from), *to, props)))
+    }
+
+    pub fn node_props(&self, Node(node): Node) -> &DepNode<'tcx, OneHopLocation> {
+        &self.assoc[node].0
     }
 
     /// Returns the set of source places that the parent can access (write to)
     pub(crate) fn parentable_srcs<'a>(&'a self) -> FxHashSet<(DepNode<'tcx, bool>, Option<u8>)> {
-        self.edges
-            .iter()
-            .filter(|&(n, _, _)| n.at.location.is_start())
+        self.iter_edges()
+            .filter(|&(n, _, _)| self.node_props(n).at.location.is_start())
             .map(|(n, _, _)| {
+                let n = self.node_props(n);
                 n.map_at(|_| {
                     assert!(n.at.in_child.is_none());
                     true
@@ -387,10 +400,10 @@ impl<'tcx, K> PartialGraph<'tcx, K> {
     /// Returns the set of destination places that the parent can access (read
     /// from)
     pub(crate) fn parentable_dsts<'a>(&'a self) -> FxHashSet<(DepNode<'tcx, bool>, Option<u8>)> {
-        self.edges
-            .iter()
-            .filter(|&(_, n, _)| n.at.location.is_end())
+        self.iter_edges()
+            .filter(|&(_, n, _)| self.node_props(n).at.location.is_end())
             .map(|(_, n, _)| {
+                let n = self.node_props(n);
                 assert!(n.at.in_child.is_none());
                 n.map_at(|_| false)
             })

--- a/crates/flowistry_pdg_construction/src/graph.rs
+++ b/crates/flowistry_pdg_construction/src/graph.rs
@@ -8,6 +8,7 @@ use std::{
 
 use flowistry_pdg::{CallString, RichLocation};
 use internment::Intern;
+use log::trace;
 use petgraph::{
     dot,
     graph::{DiGraph, EdgeIndex},
@@ -313,17 +314,8 @@ impl DepGraph<'_> {
 pub type Node = petgraph::graph::NodeIndex;
 
 #[derive(Debug, Clone)]
-pub struct DepNodeProps {
-    key: Node,
-    is_split: bool,
-    place_pretty: Option<Intern<String>>,
-    span: Span,
-}
-
-#[derive(Debug, Clone)]
 pub struct PartialGraph<'tcx, K> {
     node_mapping: FxHashMap<(Place<'tcx>, OneHopLocation), Node>,
-    edge_mapping: FxHashMap<(Node, Node), EdgeIndex>,
     graph: petgraph::Graph<DepNode<'tcx, OneHopLocation>, DepEdge<OneHopLocation>>,
     pub(crate) def_id: DefId,
     arg_count: usize,
@@ -351,7 +343,6 @@ impl<'tcx, K> PartialGraph<'tcx, K> {
     ) -> Self {
         Self {
             node_mapping: Default::default(),
-            edge_mapping: Default::default(),
             graph: petgraph::Graph::new(),
             generics,
             def_id,
@@ -387,13 +378,18 @@ impl<'tcx, K> PartialGraph<'tcx, K> {
     }
 
     pub fn insert_edge(&mut self, source: Node, target: Node, edge: DepEdge<OneHopLocation>) {
-        let key = (source, target);
-        if let Some(prior) = self.edge_mapping.get(&key) {
-            let e = self.graph.edge_weight(*prior).unwrap();
-            assert_eq!(e, &edge);
+        if let Some(prior) = self.graph.find_edge(source, target) {
+            let e = self.graph.edge_weight(prior).unwrap();
+            assert_eq!(
+                e,
+                &edge,
+                "Edge {:?} -> {:?} already exists in {:?}",
+                self.node_props(source).place,
+                self.node_props(target).place,
+                self.def_id
+            );
         } else {
-            let edge = self.graph.add_edge(source, target, edge);
-            self.edge_mapping.insert(key, edge);
+            self.graph.add_edge(source, target, edge);
         }
     }
 
@@ -437,10 +433,10 @@ impl<'tcx, K> PartialGraph<'tcx, K> {
     /// Returns the set of destination places that the parent can access (read
     /// from)
     pub(crate) fn parentable_dsts<'a>(&'a self) -> FxHashSet<(DepNode<'tcx, bool>, Option<u8>)> {
-        self.iter_edges()
-            .filter(|&(_, n, _)| self.node_props(n).at.location.is_end())
-            .map(|(_, n, _)| {
-                let n = self.node_props(n);
+        self.iter_nodes()
+            .map(|(_, n)| n)
+            .filter(|n| n.at.location.is_end())
+            .map(|n| {
                 assert!(n.at.in_child.is_none());
                 n.map_at(|_| false)
             })

--- a/crates/flowistry_pdg_construction/src/graph.rs
+++ b/crates/flowistry_pdg_construction/src/graph.rs
@@ -376,11 +376,13 @@ impl<'tcx, K> PartialGraph<'tcx, K> {
         at: OneHopLocation,
         construct: impl FnOnce() -> DepNode<'tcx, OneHopLocation>,
     ) -> Node {
-        if let Some(node) = self.get_node(place, at) {
+        if let Some(node) = self.get_node(place, at.clone()) {
             node
         } else {
             let node = construct();
-            self.insert_node(node)
+            let idx = self.graph.add_node(node);
+            self.node_mapping.insert((place, at), idx);
+            idx
         }
     }
 

--- a/crates/flowistry_pdg_construction/src/graph.rs
+++ b/crates/flowistry_pdg_construction/src/graph.rs
@@ -334,7 +334,7 @@ impl<'tcx, K> HasLocalDecls<'tcx> for PartialGraph<'tcx, K> {
 }
 
 impl<'tcx, K> PartialGraph<'tcx, K> {
-    pub fn new(
+    pub(crate) fn new(
         generics: GenericArgsRef<'tcx>,
         def_id: DefId,
         arg_count: usize,
@@ -357,7 +357,7 @@ impl<'tcx, K> PartialGraph<'tcx, K> {
         self.def_id
     }
 
-    pub fn insert_node(&mut self, node: DepNode<'tcx, OneHopLocation>) -> Node {
+    pub(crate) fn insert_node(&mut self, node: DepNode<'tcx, OneHopLocation>) -> Node {
         self.get_or_construct_node(node.place, node.at.clone(), || node)
     }
 
@@ -365,7 +365,7 @@ impl<'tcx, K> PartialGraph<'tcx, K> {
         self.node_mapping.get(&(place, at)).copied()
     }
 
-    pub fn get_or_construct_node(
+    pub(crate) fn get_or_construct_node(
         &mut self,
         place: Place<'tcx>,
         at: OneHopLocation,
@@ -381,7 +381,12 @@ impl<'tcx, K> PartialGraph<'tcx, K> {
         }
     }
 
-    pub fn insert_edge(&mut self, source: Node, target: Node, edge: DepEdge<OneHopLocation>) {
+    pub(crate) fn insert_edge(
+        &mut self,
+        source: Node,
+        target: Node,
+        edge: DepEdge<OneHopLocation>,
+    ) {
         if let Some(prior) = self.graph.find_edge(source, target) {
             let e = self.graph.edge_weight(prior).unwrap();
             assert_eq!(

--- a/crates/flowistry_pdg_construction/src/graph.rs
+++ b/crates/flowistry_pdg_construction/src/graph.rs
@@ -317,10 +317,15 @@ pub struct PartialGraph<'tcx, K> {
     pub(crate) generics: GenericArgsRef<'tcx>,
     local_decls: IndexVec<Local, LocalDecl<'tcx>>,
     pub(crate) k: K,
-    pub(crate) inlined_calls: Vec<(Location, Instance<'tcx>, K, Vec<GraphConnectionPoint<'tcx>>)>,
+    pub(crate) inlined_calls: Vec<(
+        Location,
+        Instance<'tcx>,
+        K,
+        Vec<GraphConnectionPoint<'tcx, OneHopLocation>>,
+    )>,
 }
 
-pub type GraphConnectionPoint<'tcx> = (Node, DepEdge<OneHopLocation>);
+pub type GraphConnectionPoint<'tcx, Loc> = (Node, DepEdge<Loc>);
 
 impl<'tcx, K> HasLocalDecls<'tcx> for PartialGraph<'tcx, K> {
     fn local_decls(&self) -> &LocalDecls<'tcx> {

--- a/crates/flowistry_pdg_construction/src/lib.rs
+++ b/crates/flowistry_pdg_construction/src/lib.rs
@@ -34,7 +34,7 @@ use rustc_middle::ty::TyCtxt;
 mod approximation;
 mod async_support;
 pub mod body_cache;
-pub(crate) mod call_tree_visit;
+pub mod call_tree_visit;
 pub mod calling_convention;
 mod construct;
 pub mod encoder;

--- a/crates/flowistry_pdg_construction/src/local_analysis.rs
+++ b/crates/flowistry_pdg_construction/src/local_analysis.rs
@@ -28,9 +28,7 @@ use crate::{
     async_support::{self, *},
     body_cache::CachedBody,
     calling_convention::*,
-    graph::{
-        DepEdge, DepNode, GraphConnectionPoint, OneHopLocation, PartialGraph, SourceUse, TargetUse,
-    },
+    graph::{DepEdge, DepNode, OneHopLocation, PartialGraph, SourceUse, TargetUse},
     mutation::{ModularMutationVisitor, Mutation, Time},
     utils::{
         self, handle_shims, is_async, is_virtual, place_ty_eq, try_monomorphize, ShimResult,

--- a/crates/flowistry_pdg_construction/src/local_analysis.rs
+++ b/crates/flowistry_pdg_construction/src/local_analysis.rs
@@ -745,10 +745,10 @@ impl<'tcx, 'a, K: Hash + Eq + Clone> LocalAnalysis<'tcx, 'a, K> {
                 };
                 for location in locations {
                     let src = final_state.get_node(*place, location.into()).unwrap();
-                    let dst =
-                        final_state.get_or_construct_node(*place, RichLocation::End.into(), || {
-                            self.make_dep_node(*place, *location)
-                        });
+                    let eloc = RichLocation::End;
+                    let dst = final_state.get_or_construct_node(*place, eloc.into(), || {
+                        self.make_dep_node(*place, eloc)
+                    });
                     let edge = DepEdge::data(
                         self.mono_body.terminator_loc(block).into(),
                         SourceUse::Operand,

--- a/crates/flowistry_pdg_construction/src/local_analysis.rs
+++ b/crates/flowistry_pdg_construction/src/local_analysis.rs
@@ -28,7 +28,9 @@ use crate::{
     async_support::{self, *},
     body_cache::CachedBody,
     calling_convention::*,
-    graph::{DepEdge, DepNode, OneHopLocation, PartialGraph, SourceUse, TargetUse},
+    graph::{
+        DepEdge, DepNode, GraphConnectionPoint, OneHopLocation, PartialGraph, SourceUse, TargetUse,
+    },
     mutation::{ModularMutationVisitor, Mutation, Time},
     utils::{
         self, handle_shims, is_async, is_virtual, place_ty_eq, try_monomorphize, ShimResult,
@@ -86,7 +88,7 @@ impl<'tcx, 'a, K> LocalAnalysis<'tcx, 'a, K> {
     pub(crate) fn find_control_inputs(
         &self,
         location: Location,
-    ) -> Vec<(DepNode<'tcx, OneHopLocation>, DepEdge<OneHopLocation>)> {
+    ) -> Vec<(Place<'tcx>, OneHopLocation, DepEdge<OneHopLocation>)> {
         let mut blocks_seen = HashSet::<BasicBlock>::from_iter(Some(location.block));
         let mut block_queue = vec![location.block];
         let mut out = vec![];
@@ -116,10 +118,9 @@ impl<'tcx, 'a, K> LocalAnalysis<'tcx, 'a, K> {
                     let Some(ctrl_place) = discr.place() else {
                         continue;
                     };
-                    let at = ctrl_loc.into();
-                    let src = self.make_dep_node(ctrl_place, ctrl_loc);
-                    let edge = DepEdge::control(at, SourceUse::Operand, TargetUse::Assign);
-                    out.push((src, edge));
+                    let at: OneHopLocation = ctrl_loc.into();
+                    let edge = DepEdge::control(at.clone(), SourceUse::Operand, TargetUse::Assign);
+                    out.push((ctrl_place, at, edge));
                 }
             }
         }
@@ -743,14 +744,17 @@ impl<'tcx, 'a, K: Hash + Eq + Clone> LocalAnalysis<'tcx, 'a, K> {
                     continue;
                 };
                 for location in locations {
-                    let src = self.make_dep_node(*place, *location);
-                    let dst = self.make_dep_node(*place, RichLocation::End);
+                    let src = final_state.get_node(*place, location.into()).unwrap();
+                    let dst =
+                        final_state.get_or_construct_node(*place, RichLocation::End.into(), || {
+                            self.make_dep_node(*place, *location)
+                        });
                     let edge = DepEdge::data(
                         self.mono_body.terminator_loc(block).into(),
                         SourceUse::Operand,
                         ret_kind,
                     );
-                    final_state.edges.insert((src, dst, edge));
+                    final_state.insert_edge(src, dst, edge);
                 }
             }
         }

--- a/crates/flowistry_pdg_construction/src/local_analysis.rs
+++ b/crates/flowistry_pdg_construction/src/local_analysis.rs
@@ -135,7 +135,7 @@ impl<'tcx, 'a, K> LocalAnalysis<'tcx, 'a, K> {
         &self.memo.async_info
     }
 
-    fn make_dep_node(
+    pub(super) fn make_dep_node(
         &self,
         place: Place<'tcx>,
         location: impl Into<RichLocation>,

--- a/crates/flowistry_pdg_construction/src/utils.rs
+++ b/crates/flowistry_pdg_construction/src/utils.rs
@@ -1,4 +1,4 @@
-use std::{collections::hash_map::Entry, hash::Hash};
+use std::{collections::hash_map::Entry, fmt::Formatter, hash::Hash};
 
 use either::Either;
 
@@ -21,6 +21,14 @@ use rustc_middle::{
 use rustc_span::{source_map::Spanned, ErrorGuaranteed, Span};
 use rustc_type_ir::{fold::TypeFoldable, AliasTyKind, PredicatePolarity, RegionKind};
 use rustc_utils::{BodyExt, PlaceExt};
+
+pub struct Print<F: Fn(&mut Formatter<'_>) -> std::fmt::Result>(pub F);
+
+impl<F: Fn(&mut Formatter<'_>) -> std::fmt::Result> std::fmt::Display for Print<F> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        (self.0)(f)
+    }
+}
 
 /// An async check that does not crash if called on closures.
 pub fn is_async(tcx: TyCtxt<'_>, def_id: DefId) -> bool {

--- a/crates/flowistry_pdg_construction/tests/pdg.rs
+++ b/crates/flowistry_pdg_construction/tests/pdg.rs
@@ -67,19 +67,11 @@ fn pdg(
             configure(tcx, &mut memo);
             let policy = memo.take_call_changes_policy();
             memo.with_call_change_callback(LocalLoadingOnly(policy));
+            memo.with_dump_mir(std::env::var("DUMP_MIR").is_ok());
             let pdg = memo.construct_graph(def_id);
             tests(tcx, memo.body_cache(), pdg)
         },
     )
-}
-
-#[allow(unused)]
-fn viz(g: &DepGraph<'_>) {
-    g.generate_graphviz(format!(
-        "{}/../../target/graph.pdf",
-        env!("CARGO_MANIFEST_DIR")
-    ))
-    .unwrap();
 }
 
 fn connects<'tcx>(

--- a/crates/paralegal-flow/src/ana/graph_converter.rs
+++ b/crates/paralegal-flow/src/ana/graph_converter.rs
@@ -71,27 +71,33 @@ fn assert_edge_location_invariant<'tcx, Loc: Eq + std::fmt::Display>(
 }
 
 struct GraphAssembler<'tcx, 'a> {
-    graph: SPDGImpl,
-    // nodes: FxHashMap<DepNode<'tcx, CallString>, petgraph::graph::NodeIndex>,
-    // control_inputs: Box<[(NodeIndex, DepEdge<CallString>)]>,
-    marker_assignments: HashMap<GNode, HashSet<Identifier>>,
-    known_def_ids: &'a mut FxHashSet<DefId>,
-    /// A map of which nodes are of which (marked) type. We build this up during
-    /// conversion.
-    types: HashMap<GNode, Vec<DefId>>,
+    // read-only information
     generator: &'a SPDGGenerator<'tcx>,
     is_async: bool,
 
-    /// The translation table for the function we're currently visiting.
+    // Translation helpers
+    /// Translation tables for nodes from local PartialGraphs to the global PDG
     nodes: Vec<Vec<GNode>>,
+
+    // Incrementally built information
+    graph: SPDGImpl,
+    marker_assignments: HashMap<GNode, HashSet<Identifier>>,
+    /// A map of which nodes are of which (marked) type. We build this up during
+    /// conversion.
+    types: HashMap<GNode, Vec<DefId>>,
+    known_def_ids: &'a mut FxHashSet<DefId>,
 }
 
+/// Create a global PDG (spanning the entire call tree) starting from the given
+/// target function.
 pub fn assemble_pdg<'a>(
     generator: &'a SPDGGenerator<'_>,
     known_def_ids: &'a mut FxHashSet<DefId>,
     target: &'a FnToAnalyze,
 ) -> SPDG {
     let tcx = generator.tcx();
+
+    // Information and body of the provided target function
     let base_body_def_id = target.def_id.to_def_id();
     let base_body = generator
         .pdg_constructor
@@ -101,17 +107,27 @@ pub fn assemble_pdg<'a>(
             panic!("INVARIANT VIOLATED: body for local function {base_body_def_id:?} cannot be loaded.",)
         })
         .body();
+
     let async_state = determine_async(tcx, base_body_def_id, base_body);
 
+    // These will refer to the function we are actually analyzing from, which may
+    // be a generator if the target is async.
     let possibly_generator_id =
         async_state.map_or(base_body_def_id, |(generator, ..)| generator.def_id());
-
     let (possible_generator_instance, k) = generator
         .pdg_constructor
         .create_root_key(possibly_generator_id.expect_local());
+
     let mut driver = VisitDriver::new(&generator.pdg_constructor, possible_generator_instance, k);
     let mut assembler = GraphAssembler::new(generator, known_def_ids, target.def_id.to_def_id());
-    if let Some((generator_instance, loc, ..)) = async_state {
+
+    // If the top level function is async we start analysis from the generator
+    // instead (because the async function itself is basically empty, it just
+    // creates the generator object).
+    if let Some((_, loc, ..)) = async_state {
+        // If the top-level function is async we place that on the call stack
+        // first so it shows up in the call strings that are generated for the
+        // nodes.
         driver.with_pushed_stack(
             GlobalLocation {
                 function: base_body_def_id,
@@ -127,7 +143,9 @@ pub fn assemble_pdg<'a>(
             .pdg_constructor
             .create_root_key(base_body_def_id.expect_local())
             .0;
-        assembler.fix_async_args(base_instance, generator_instance, loc, &mut driver);
+        // Because we actually started the analysis from the generator, we now
+        // have to manually sync up the actual arguments to the async function.
+        assembler.fix_async_args(base_instance, loc, &mut driver);
     } else {
         driver.start(&mut assembler);
     }
@@ -177,6 +195,7 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         }
     }
 
+    /// Add these markers to our marker table we maintain for nodes.
     fn register_markers(&mut self, node: GNode, markers: impl IntoIterator<Item = Identifier>) {
         let mut markers = markers.into_iter().peekable();
 
@@ -188,6 +207,8 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         }
     }
 
+    /// Add a node from the current local graph to the global graph. Returns the
+    /// global index. If the node was already added, returns the prior index.
     fn add_node<K: Clone>(
         &mut self,
         node: Node,
@@ -206,6 +227,8 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         }
     }
 
+    /// Add a node that does not correspond to any local graph. This is only used
+    /// when fixing async args.
     fn add_untranslatable_node(
         &mut self,
         place: mir::Place,
@@ -321,6 +344,9 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         self.handle_node_types_helper(node, base_ty, projections);
     }
 
+    /// Adds the markers for all levels of projection on this node. For the
+    /// final projection we add all markers from that type (deep markers), for
+    /// others we only add the shallow markers.
     fn handle_node_types_helper(
         &mut self,
         node: GNode,
@@ -360,6 +386,7 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         .map(|(d, _)| d)
     }
 
+    /// Discover and register directly applied markers on this node.
     fn node_annotations<K: Clone>(
         &mut self,
         local_node: Node,
@@ -407,6 +434,7 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         self.register_annotations_for_function(node, function_id, |ann| ann.refinement.on_return());
     }
 
+    /// Helper for `node_annotations` to handle the case where the node is at a `RichLocation::Location`.
     fn handle_node_annotations_for_regular_location<K: Clone>(
         &mut self,
         local_node: Node,
@@ -562,14 +590,23 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         self.is_async
     }
 
+    /// When we analyze an async function (as entry point), we actually start
+    /// the analysis from the generator, since the async function itself is
+    /// mostly empty. However the arguments to the generator are not the same as
+    /// for the async function. It is the generator object that basically
+    /// tuples together the arguments to the original async function. (And as a
+    /// second argument there's a context object.)
+    ///
+    /// This function adds nodes for the original async function's arguments and
+    /// connects them to the fields of the generator object to establish the flows.
     fn fix_async_args<K: Clone + std::hash::Hash + Eq>(
         &mut self,
         instance: Instance<'tcx>,
-        _generator: Instance<'tcx>,
         loc: Location,
         driver: &mut VisitDriver<'tcx, 'a, K>,
     ) {
         let def_id = instance.def_id();
+        self.known_def_ids.extend([def_id]);
         let tcx = self.generator.tcx();
         let base_body = self
             .generator
@@ -580,8 +617,9 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
                 panic!("INVARIANT VIOLATED: body for local function {def_id:?} cannot be loaded.",)
             })
             .body();
-        self.known_def_ids.extend([def_id]);
         let pgraph = driver.current_graph_as_rc();
+
+        // New nodes for arguments and return place
         let args_as_nodes = base_body
             .args_iter()
             .map(|arg| {
@@ -612,16 +650,17 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
             )
         };
 
+        // Register the new nodes and add potential markers
         for (arg_num, a) in args_as_nodes.iter().enumerate() {
             self.register_annotations_for_argument(*a, arg_num as u32, def_id);
             let local = mir::Local::from_usize(arg_num + 1);
             self.handle_node_types_helper(*a, mono_ty(local), &[]);
         }
-
         self.register_annotations_for_return(return_node, def_id);
         let local = mir::RETURN_PLACE;
         self.handle_node_types_helper(return_node, mono_ty(local), &[]);
 
+        // Establish connections to existing nodes
         let generator_loc = RichLocation::Location(loc);
         let transition_at = CallString::new(&[GlobalLocation {
             location: generator_loc,
@@ -665,10 +704,12 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         }
     }
 
+    /// Translate a node from the current local graph to the global graph.
     fn translate_node(&self, node: Node) -> GNode {
         self.translate_node_in(node, self.nodes.len() - 1)
     }
 
+    /// Translate a node from a specific local graph to the global graph.
     fn translate_node_in(&self, node: Node, index: usize) -> GNode {
         let idx = self.nodes[index][node.index()];
         assert_ne!(idx.to_index(), Node::end(), "Node {node:?} is unknown");
@@ -714,7 +755,9 @@ fn globalize_edge<K: Clone>(
     }
 }
 
-/// A newtype for indices into the global graph
+/// A newtype for indices into the global graph. This type exists because under
+/// the hood local and global graphs use the same index types which makes it
+/// very easy to mistake them.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GNode(petgraph::graph::NodeIndex);
 

--- a/crates/paralegal-flow/src/ana/graph_converter.rs
+++ b/crates/paralegal-flow/src/ana/graph_converter.rs
@@ -82,6 +82,7 @@ struct GraphAssembler<'tcx, 'a> {
     /// conversion.
     types: HashMap<GNode, Vec<DefId>>,
     generator: &'a SPDGGenerator<'tcx>,
+    is_async: bool,
 
     /// The translation table for the function we're currently visiting.
     nodes: Vec<Vec<GNode>>,
@@ -162,6 +163,11 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         known_def_ids: &'a mut FxHashSet<DefId>,
         def_id: DefId,
     ) -> Self {
+        let is_async = entrypoint_is_async(
+            generator.pdg_constructor.body_cache(),
+            generator.tcx(),
+            def_id,
+        );
         Self {
             def_id,
             graph: SPDGImpl::new(),
@@ -171,6 +177,7 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
             known_def_ids,
             types: Default::default(),
             generator,
+            is_async,
         }
     }
 
@@ -308,22 +315,66 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         vis: &VisitDriver<'tcx, '_, K>,
     ) {
         trace!("Checking types for node {node:?} ({:?})", place);
-        if let Some(t) = self.determine_place_type(at, place.as_ref(), span, vis) {
-            self.handle_node_types_helper(node, place, t);
-        }
+
+        let tcx = self.tcx();
+        let function = vis.current_function();
+
+        // So actually we're going to check the base place only, because
+        // Flowistry sometimes tracks subplaces instead but we want the marker
+        // from the base place.
+        let (base_place, projections) =
+            if self.entrypoint_is_async() && place.local.as_u32() == 1 && at.in_child.is_none() {
+                if place.projection.is_empty() {
+                    return;
+                }
+                let (base_project, rest) = place.projection.split_first().unwrap();
+                // in the case of targeting the top-level async closure (e.g. async args)
+                // we'll keep the first projection.
+                (
+                    mir::Place {
+                        local: place.local,
+                        projection: self.tcx().mk_place_elems(&[*base_project]),
+                    },
+                    rest,
+                )
+            } else {
+                (place.local.into(), place.projection.as_slice())
+            };
+        trace!("Using base place {base_place:?} with projections {projections:?}");
+
+        let resolution = vis.current_function();
+
+        // Thread through each caller to recover generic arguments
+        let body = self
+            .generator
+            .pdg_constructor
+            .body_cache()
+            .get(function.def_id())
+            .body();
+        let raw_ty = base_place.ty(body, tcx);
+        let base_ty = try_monomorphize(
+            resolution,
+            tcx,
+            TypingEnv::fully_monomorphized(),
+            &raw_ty,
+            span,
+        )
+        .unwrap();
+
+        self.handle_node_types_helper(node, base_ty, projections);
     }
 
     fn handle_node_types_helper(
         &mut self,
         node: GNode,
-        place: mir::Place<'tcx>,
         mut base_ty: mir::tcx::PlaceTy<'tcx>,
+        projections: &[mir::PlaceElem<'tcx>],
     ) {
         trace!("Has place type {base_ty:?}");
         let deep = true;
         let mut node_types = self.type_is_marked(base_ty, deep).collect::<HashSet<_>>();
-        for (_, proj) in place.iter_projections() {
-            base_ty = base_ty.projection_ty(self.tcx(), proj);
+        for proj in projections {
+            base_ty = base_ty.projection_ty(self.tcx(), *proj);
             node_types.extend(self.type_is_marked(base_ty, false));
         }
         self.known_def_ids.extend(node_types.iter().copied());
@@ -335,10 +386,7 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
                     .filter(|t| !tcx.is_coroutine(**t) && !tcx.def_kind(*t).is_fn_like()),
             )
         }
-        trace!(
-            "For node {:?} found marked node types {node_types:?}",
-            place
-        );
+        trace!("Found marked node types {node_types:?}",);
     }
 
     /// Return the (sub)types of this type that are marked.
@@ -355,57 +403,6 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         .map(|(d, _)| d)
     }
 
-    /// Reconstruct the type for the data this node represents.
-    fn determine_place_type<K: Clone>(
-        &self,
-        at: &OneHopLocation,
-        place: mir::PlaceRef<'tcx>,
-        span: rustc_span::Span,
-        vis: &VisitDriver<'tcx, '_, K>,
-    ) -> Option<mir::tcx::PlaceTy<'tcx>> {
-        let tcx = self.tcx();
-        let function = vis.current_function();
-
-        // So actually we're going to check the base place only, because
-        // Flowistry sometimes tracks subplaces instead but we want the marker
-        // from the base place.
-        let place =
-            if self.entrypoint_is_async() && place.local.as_u32() == 1 && at.in_child.is_none() {
-                if place.projection.is_empty() {
-                    return None;
-                }
-                // in the case of targeting the top-level async closure (e.g. async args)
-                // we'll keep the first projection.
-                mir::Place {
-                    local: place.local,
-                    projection: self.tcx().mk_place_elems(&place.projection[..1]),
-                }
-            } else {
-                place.local.into()
-            };
-
-        let resolution = vis.current_function();
-
-        // Thread through each caller to recover generic arguments
-        let body = self
-            .generator
-            .pdg_constructor
-            .body_cache()
-            .get(function.def_id())
-            .body();
-        let raw_ty = place.ty(body, tcx);
-        Some(
-            try_monomorphize(
-                resolution,
-                tcx,
-                TypingEnv::fully_monomorphized(),
-                &raw_ty,
-                span,
-            )
-            .unwrap(),
-        )
-    }
-
     fn node_annotations<K: Clone>(
         &mut self,
         local_node: Node,
@@ -413,10 +410,6 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         weight: &DepNode<'tcx, OneHopLocation>,
         vis: &VisitDriver<'tcx, '_, K>,
     ) {
-        if weight.at.in_child.is_some() {
-            // Transition nodes are handled again in the child right?
-            return;
-        }
         let leaf_loc = weight.at.location;
         let function = vis.current_function();
         let function_id = function.def_id();
@@ -609,11 +602,7 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
 
     /// Is the top-level function (entrypoint) an `async fn`
     fn entrypoint_is_async(&self) -> bool {
-        entrypoint_is_async(
-            self.generator.pdg_constructor.body_cache(),
-            self.tcx(),
-            self.def_id,
-        )
+        self.is_async
     }
 
     fn fix_async_args<K: Clone + std::hash::Hash + Eq>(
@@ -652,28 +641,29 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
             base_body.local_decls[mir::RETURN_PLACE].source_info.span,
         );
 
-        let mono_ty = |place: mir::Place<'tcx>| {
-            let base_ty = place.ty(base_body, tcx);
-            try_monomorphize(
-                instance,
-                tcx,
-                TypingEnv::fully_monomorphized(),
-                &base_ty,
-                base_body.local_decls[place.local].source_info.span,
+        let mono_ty = |local| {
+            let decl = &base_body.local_decls[local];
+            mir::tcx::PlaceTy::from_ty(
+                try_monomorphize(
+                    instance,
+                    tcx,
+                    TypingEnv::fully_monomorphized(),
+                    &decl.ty,
+                    decl.source_info.span,
+                )
+                .unwrap(),
             )
-            .unwrap()
         };
 
         for (arg_num, a) in args_as_nodes.iter().enumerate() {
             self.register_annotations_for_argument(*a, arg_num as u32, def_id);
             let local = mir::Local::from_usize(arg_num + 1);
-            let place: mir::Place<'tcx> = local.into();
-            self.handle_node_types_helper(*a, place, mono_ty(place));
+            self.handle_node_types_helper(*a, mono_ty(local), &[]);
         }
 
         self.register_annotations_for_return(return_node, def_id);
-        let place: mir::Place<'tcx> = mir::RETURN_PLACE.into();
-        self.handle_node_types_helper(return_node, place, mono_ty(place));
+        let local = mir::RETURN_PLACE;
+        self.handle_node_types_helper(return_node, mono_ty(local), &[]);
 
         let generator_loc = RichLocation::Location(loc);
         let transition_at = CallString::new(&[GlobalLocation {
@@ -804,9 +794,12 @@ impl<'tcx, K: std::hash::Hash + Eq + Clone> Visitor<'tcx, K> for GraphAssembler<
         k: Node,
         node: &DepNode<'tcx, OneHopLocation>,
     ) {
+        let is_in_child = node.at.in_child.is_some();
         let idx = self.add_node(k, vis, node);
-        self.node_annotations(k, idx, node, vis);
-        self.handle_node_types(idx, &node.at, node.place, node.span, vis);
+        if !is_in_child {
+            self.node_annotations(k, idx, node, vis);
+            self.handle_node_types(idx, &node.at, node.place, node.span, vis);
+        }
     }
 
     fn visit_edge(
@@ -829,6 +822,10 @@ impl<'tcx, K: std::hash::Hash + Eq + Clone> Visitor<'tcx, K> for GraphAssembler<
         graph: &PartialGraph<'tcx, K>,
     ) {
         self.with_new_translation_table(graph.node_count(), |slf: &mut Self| {
+            trace!(
+                "Visiting partial graph {:?}",
+                slf.tcx().def_path_str(graph.def_id())
+            );
             vis.visit_partial_graph(slf, graph);
 
             // TODO move to driver

--- a/crates/paralegal-flow/src/ana/graph_converter.rs
+++ b/crates/paralegal-flow/src/ana/graph_converter.rs
@@ -1204,17 +1204,17 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
                     if eref.weight().kind == DepEdgeKind::Data {
                         has_no_data_edges = false;
                         let at = eref.weight().at.clone();
-                        #[cfg(debug_assertions)]
-                        assert_edge_location_invariant(
-                            self.tcx(),
-                            at.clone(),
-                            body,
-                            weight.at.clone(),
-                            |at| GlobalLocation {
-                                function: function.def_id(),
-                                location: at.location,
-                            },
-                        );
+                        // #[cfg(debug_assertions)]
+                        // assert_edge_location_invariant(
+                        //     self.tcx(),
+                        //     at.clone(),
+                        //     body,
+                        //     weight.at.clone(),
+                        //     |at| GlobalLocation {
+                        //         function: function.def_id(),
+                        //         location: at.location,
+                        //     },
+                        // );
                         if weight.at == at && eref.weight().target_use.is_return() {
                             is_return_use = true;
                         }

--- a/crates/paralegal-flow/src/ana/graph_converter.rs
+++ b/crates/paralegal-flow/src/ana/graph_converter.rs
@@ -93,35 +93,42 @@ pub fn assemble_pdg<'a>(
     target: &'a FnToAnalyze,
 ) -> SPDG {
     let tcx = generator.tcx();
-    let def_id = target.def_id.to_def_id();
+    let base_body_def_id = target.def_id.to_def_id();
     let base_body = generator
         .pdg_constructor
         .body_cache()
-        .try_get(def_id)
+        .try_get(base_body_def_id)
         .unwrap_or_else(|| {
-            panic!("INVARIANT VIOLATED: body for local function {def_id:?} cannot be loaded.",)
+            panic!("INVARIANT VIOLATED: body for local function {base_body_def_id:?} cannot be loaded.",)
         })
         .body();
-    let async_state = determine_async(tcx, def_id, base_body);
+    let async_state = determine_async(tcx, base_body_def_id, base_body);
 
-    let base_function_id = async_state.map_or(def_id, |(generator, ..)| generator.def_id());
+    let possibly_generator_id =
+        async_state.map_or(base_body_def_id, |(generator, ..)| generator.def_id());
 
-    let (instance, k) = generator
+    let (possible_generator_instance, k) = generator
         .pdg_constructor
-        .create_root_key(base_function_id.expect_local());
-    let mut driver = VisitDriver::new(&generator.pdg_constructor, instance, k);
+        .create_root_key(possibly_generator_id.expect_local());
+    let mut driver = VisitDriver::new(&generator.pdg_constructor, possible_generator_instance, k);
     let mut assembler = GraphAssembler::new(generator, known_def_ids, target.def_id.to_def_id());
-    if let Some((generator, loc, ..)) = async_state {
+    if let Some((generator_instance, loc, ..)) = async_state {
         driver.with_pushed_stack(
             GlobalLocation {
-                function: def_id,
+                function: base_body_def_id,
                 location: RichLocation::Location(loc),
             },
             |driver| {
                 driver.start(&mut assembler);
             },
         );
-        assembler.fix_async_args(def_id, generator, loc, &mut driver);
+        // Using create_root_key might seem weird here but it currently does what
+        // we need (resolve the instance)
+        let base_instance = generator
+            .pdg_constructor
+            .create_root_key(base_body_def_id.expect_local())
+            .0;
+        assembler.fix_async_args(base_instance, generator_instance, loc, &mut driver);
     } else {
         driver.start(&mut assembler);
     }
@@ -295,25 +302,29 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
     fn handle_node_types<K: Clone>(
         &mut self,
         node: GNode,
-        weight: &DepNode<'tcx, OneHopLocation>,
+        at: &OneHopLocation,
+        place: mir::Place<'tcx>,
+        span: rustc_span::Span,
         vis: &VisitDriver<'tcx, '_, K>,
     ) {
-        trace!("Checking types for node {node:?} ({:?})", weight.place);
+        trace!("Checking types for node {node:?} ({:?})", place);
+        if let Some(t) = self.determine_place_type(at, place.as_ref(), span, vis) {
+            self.handle_node_types_helper(node, place, t);
+        }
+    }
 
-        let Some(place_ty) =
-            self.determine_place_type(&weight.at, weight.place.as_ref(), weight.span, vis)
-        else {
-            return;
-        };
-        trace!("Has place type {:?}", place_ty);
-        // Restore after fixing https://github.com/brownsys/paralegal/issues/138
-        //let deep = !weight.is_split;
+    fn handle_node_types_helper(
+        &mut self,
+        node: GNode,
+        place: mir::Place<'tcx>,
+        mut base_ty: mir::tcx::PlaceTy<'tcx>,
+    ) {
+        trace!("Has place type {base_ty:?}");
         let deep = true;
-        let mut node_types = self.type_is_marked(place_ty, deep).collect::<HashSet<_>>();
-        for (p, _) in weight.place.iter_projections() {
-            if let Some(place_ty) = self.determine_place_type(&weight.at, p, weight.span, vis) {
-                node_types.extend(self.type_is_marked(place_ty, false));
-            }
+        let mut node_types = self.type_is_marked(base_ty, deep).collect::<HashSet<_>>();
+        for (_, proj) in place.iter_projections() {
+            base_ty = base_ty.projection_ty(self.tcx(), proj);
+            node_types.extend(self.type_is_marked(base_ty, false));
         }
         self.known_def_ids.extend(node_types.iter().copied());
         let tcx = self.tcx();
@@ -326,7 +337,7 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         }
         trace!(
             "For node {:?} found marked node types {node_types:?}",
-            weight.place
+            place
         );
     }
 
@@ -422,23 +433,28 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
                 if matches!(body.local_kind(weight.place.local), mir::LocalKind::Arg) =>
             {
                 let arg_num = weight.place.local.as_u32() - 1;
-                self.known_def_ids.extend(Some(function_id));
-
-                self.register_annotations_for_function(node, function_id, |ann| {
-                    ann.refinement.on_argument().contains(arg_num).unwrap()
-                });
+                self.known_def_ids.extend([function_id]);
+                self.register_annotations_for_argument(node, arg_num, function_id);
             }
             RichLocation::End if weight.place.local == mir::RETURN_PLACE => {
-                self.known_def_ids.extend(Some(function_id));
-                self.register_annotations_for_function(node, function_id, |ann| {
-                    ann.refinement.on_return()
-                });
+                self.known_def_ids.extend([function_id]);
+                self.register_annotations_for_return(node, function_id);
             }
             RichLocation::Location(loc) => self.handle_node_annotations_for_regular_location(
                 local_node, node, weight, body, loc, vis,
             ),
             _ => (),
         }
+    }
+
+    fn register_annotations_for_argument(&mut self, node: GNode, arg_num: u32, function_id: DefId) {
+        self.register_annotations_for_function(node, function_id, |ann| {
+            ann.refinement.on_argument().contains(arg_num).unwrap()
+        });
+    }
+
+    fn register_annotations_for_return(&mut self, node: GNode, function_id: DefId) {
+        self.register_annotations_for_function(node, function_id, |ann| ann.refinement.on_return());
     }
 
     fn handle_node_annotations_for_regular_location<K: Clone>(
@@ -588,13 +604,7 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
     /// Similar to `CallString::is_at_root`, but takes into account top-level
     /// async functions
     fn try_as_root(&self, at: CallString) -> Option<GlobalLocation> {
-        if self.entrypoint_is_async() && at.len() == 2 {
-            at.iter_from_root().nth(1)
-        } else if at.is_at_root() {
-            Some(at.leaf())
-        } else {
-            None
-        }
+        at.is_at_root().then(|| at.leaf())
     }
 
     /// Is the top-level function (entrypoint) an `async fn`
@@ -608,11 +618,12 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
 
     fn fix_async_args<K: Clone + std::hash::Hash + Eq>(
         &mut self,
-        def_id: DefId,
+        instance: Instance<'tcx>,
         _generator: Instance<'tcx>,
         loc: Location,
         driver: &mut VisitDriver<'tcx, 'a, K>,
     ) {
+        let def_id = instance.def_id();
         let tcx = self.generator.tcx();
         let base_body = self
             .generator
@@ -623,6 +634,7 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
                 panic!("INVARIANT VIOLATED: body for local function {def_id:?} cannot be loaded.",)
             })
             .body();
+        self.known_def_ids.extend([def_id]);
         let pgraph = driver.current_graph_as_rc();
         let args_as_nodes = base_body
             .args_iter()
@@ -639,6 +651,30 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
             driver.globalize_location(&RichLocation::End.into()),
             base_body.local_decls[mir::RETURN_PLACE].source_info.span,
         );
+
+        let mono_ty = |place: mir::Place<'tcx>| {
+            let base_ty = place.ty(base_body, tcx);
+            try_monomorphize(
+                instance,
+                tcx,
+                TypingEnv::fully_monomorphized(),
+                &base_ty,
+                base_body.local_decls[place.local].source_info.span,
+            )
+            .unwrap()
+        };
+
+        for (arg_num, a) in args_as_nodes.iter().enumerate() {
+            self.register_annotations_for_argument(*a, arg_num as u32, def_id);
+            let local = mir::Local::from_usize(arg_num + 1);
+            let place: mir::Place<'tcx> = local.into();
+            self.handle_node_types_helper(*a, place, mono_ty(place));
+        }
+
+        self.register_annotations_for_return(return_node, def_id);
+        let place: mir::Place<'tcx> = mir::RETURN_PLACE.into();
+        self.handle_node_types_helper(return_node, place, mono_ty(place));
+
         let generator_loc = RichLocation::Location(loc);
         let transition_at = CallString::new(&[GlobalLocation {
             location: generator_loc,
@@ -770,7 +806,7 @@ impl<'tcx, K: std::hash::Hash + Eq + Clone> Visitor<'tcx, K> for GraphAssembler<
     ) {
         let idx = self.add_node(k, vis, node);
         self.node_annotations(k, idx, node, vis);
-        self.handle_node_types(idx, node, vis);
+        self.handle_node_types(idx, &node.at, node.place, node.span, vis);
     }
 
     fn visit_edge(

--- a/crates/paralegal-flow/src/ana/graph_converter.rs
+++ b/crates/paralegal-flow/src/ana/graph_converter.rs
@@ -1,554 +1,27 @@
-use std::{marker::PhantomData, rc::Rc, time::Instant};
-
-use self::call_string_resolver::CallStringResolver;
-use super::{default_index, path_for_item, src_loc_for_span, SPDGGenerator};
+use super::{path_for_item, src_loc_for_span, SPDGGenerator};
 use crate::{
-    ann::MarkerAnnotation, desc::*, discover::FnToAnalyze, stats::TimedStat, utils::*, HashMap,
-    HashSet, MarkerCtx, Pctx,
+    ann::MarkerAnnotation, desc::*, discover::FnToAnalyze, utils::*, HashMap, HashSet, MarkerCtx,
+    Pctx,
 };
 use flowistry_pdg::{rustc_portable::Location, SourceUse};
 use flowistry_pdg_construction::{
-    body_cache::BodyCache,
     call_tree_visit::{VisitDriver, Visitor},
     determine_async,
-    graph::{
-        DepEdge, DepEdgeKind, DepGraph, DepNode, GraphConnectionPoint, OneHopLocation, PartialGraph,
-    },
-    is_async_trait_fn, match_async_trait_assign,
+    graph::{DepEdge, DepEdgeKind, DepNode, GraphConnectionPoint, OneHopLocation, PartialGraph},
     utils::{handle_shims, try_monomorphize, try_resolve_function, type_as_fn, ShimResult},
 };
-use paralegal_spdg::{Node, SPDGStats};
+use paralegal_spdg::Node;
 
-use rustc_hash::{FxHashMap, FxHashSet};
-use rustc_hir::def_id::{DefId, LocalDefId};
+use rustc_hash::FxHashSet;
+use rustc_hir::def_id::DefId;
 use rustc_middle::{
     mir,
-    ty::{self, Instance, TyCtxt, TypingEnv},
+    ty::{Instance, TyCtxt, TypingEnv},
 };
 
-use anyhow::Result;
 use either::Either;
 use flowistry::mir::FlowistryInput;
-use petgraph::{
-    visit::{IntoNodeReferences, NodeIndexable, NodeRef},
-    Direction::{self, Outgoing},
-};
-
-/// Structure responsible for converting one [`DepGraph`] into an [`SPDG`].
-///
-/// Intended usage is to call [`Self::new_with_flowistry`] to initialize, then
-/// [`Self::make_spdg`] to convert.
-pub struct GraphConverter<'tcx, 'a, C> {
-    // Immutable information
-    /// The parent generator
-    generator: &'a SPDGGenerator<'tcx>,
-    /// Information about the function this PDG belongs to
-    target: &'a FnToAnalyze,
-    /// The flowistry graph we are converting
-    dep_graph: Rc<DepGraph<'tcx>>,
-    /// Same as the ID stored in self.target, but as a local def id
-    def_id: DefId,
-
-    // Mutable fields
-    /// Where we write every [`DefId`] we encounter into.
-    known_def_ids: &'a mut C,
-    /// A map of which nodes are of which (marked) type. We build this up during
-    /// conversion.
-    types: HashMap<Node, Vec<DefId>>,
-    /// Mapping from old node indices to new node indices. Use
-    /// [`Self::register_node`] to insert and [`Self::new_node_for`] to query.
-    index_map: Box<[Node]>,
-    /// The converted graph we are creating
-    spdg: SPDGImpl,
-    marker_assignments: HashMap<Node, HashSet<Identifier>>,
-    call_string_resolver: call_string_resolver::CallStringResolver<'tcx>,
-    stats: SPDGStats,
-}
-
-impl<'a, 'tcx, C: Extend<DefId>> GraphConverter<'tcx, 'a, C> {
-    /// Initialize a new converter by creating an initial PDG using flowistry.
-    pub fn new_with_flowistry(
-        generator: &'a SPDGGenerator<'tcx>,
-        known_def_ids: &'a mut C,
-        target: &'a FnToAnalyze,
-    ) -> Result<Self> {
-        let local_def_id = target.def_id;
-        let (dep_graph, stats) = generator.stats.measure(TimedStat::Flowistry, || {
-            Self::create_flowistry_graph(generator, local_def_id)
-        })?;
-
-        log::info!("Flowistry graph created for {}", target.name());
-
-        if generator.ctx.opts().dbg().dump_flowistry_pdg() {
-            dep_graph.generate_graphviz(format!(
-                "{}.flowistry-pdg.pdf",
-                generator.tcx().def_path_str(target.def_id)
-            ))?
-        }
-
-        let def_id = local_def_id.to_def_id();
-
-        Ok(Self {
-            generator,
-            known_def_ids,
-            target,
-            index_map: vec![default_index(); dep_graph.graph.node_bound()].into(),
-            dep_graph: dep_graph.into(),
-            def_id,
-            types: Default::default(),
-            spdg: Default::default(),
-            marker_assignments: Default::default(),
-            call_string_resolver: CallStringResolver::new(generator.ctx.clone(), def_id),
-            stats,
-        })
-    }
-
-    fn tcx(&self) -> TyCtxt<'tcx> {
-        self.generator.tcx()
-    }
-
-    fn ctx(&self) -> &Pctx<'tcx> {
-        &self.generator.ctx
-    }
-
-    fn marker_ctx(&self) -> &MarkerCtx<'tcx> {
-        self.generator.marker_ctx()
-    }
-
-    /// Is the top-level function (entrypoint) an `async fn`
-    fn entrypoint_is_async(&self) -> bool {
-        entrypoint_is_async(self.body_cache(), self.tcx(), self.def_id)
-    }
-
-    /// Insert this node into the converted graph, return it's auto-assigned id
-    /// and register it as corresponding to `old` in the initial graph. Fails if
-    /// there is already a node registered as corresponding to `old`.
-    fn register_node(&mut self, old: Node, new: NodeInfo) -> Node {
-        let new_node = self.spdg.add_node(new);
-        let r = &mut self.index_map[old.index()];
-        assert_eq!(*r, default_index());
-        *r = new_node;
-        new_node
-    }
-
-    /// Get the id of the new node that was registered for this old node.
-    fn new_node_for(&self, old: Node) -> Node {
-        let res = self.index_map[old.index()];
-        assert_ne!(res, default_index());
-        res
-    }
-
-    fn register_markers(&mut self, node: Node, markers: impl IntoIterator<Item = Identifier>) {
-        let mut markers = markers.into_iter().peekable();
-
-        if markers.peek().is_some() {
-            self.marker_assignments
-                .entry(node)
-                .or_default()
-                .extend(markers);
-        }
-    }
-
-    /// Find direct annotations on this node and register them in the marker map.
-    fn node_annotations(&mut self, old_node: Node, weight: &DepNode<'tcx, CallString>) {
-        let leaf_loc = weight.at.leaf();
-        let node = self.new_node_for(old_node);
-
-        let body = self.body_cache().get(leaf_loc.function).body();
-
-        let graph = self.dep_graph.clone();
-
-        match leaf_loc.location {
-            RichLocation::Start
-                if matches!(body.local_kind(weight.place.local), mir::LocalKind::Arg) =>
-            {
-                let function_id = leaf_loc.function;
-                let arg_num = weight.place.local.as_u32() - 1;
-                self.known_def_ids.extend(Some(function_id));
-
-                self.register_annotations_for_function(node, function_id, |ann| {
-                    ann.refinement.on_argument().contains(arg_num).unwrap()
-                });
-            }
-            RichLocation::End if weight.place.local == mir::RETURN_PLACE => {
-                let function_id = leaf_loc.function;
-                self.known_def_ids.extend(Some(function_id));
-                self.register_annotations_for_function(node, function_id, |ann| {
-                    ann.refinement.on_return()
-                });
-            }
-            RichLocation::Location(loc) => {
-                let crate::Either::Right(
-                    term @ mir::Terminator {
-                        kind: mir::TerminatorKind::Call { func, .. },
-                        ..
-                    },
-                ) = body.stmt_at(loc)
-                else {
-                    return;
-                };
-                debug!("Assigning markers to {:?}", term.kind);
-                let res = self.call_string_resolver.resolve(weight.at);
-                let param_env = TypingEnv::post_analysis(self.tcx(), res.def_id());
-                let func =
-                    try_monomorphize(res, self.tcx(), param_env, func, term.source_info.span)
-                        .unwrap();
-                let Some(funcc) = func.constant() else {
-                    self.ctx().maybe_span_err(
-                        weight.span,
-                        "SOUNDNESS: Cannot determine markers for function call",
-                    );
-                    return;
-                };
-                let (inst, args) = type_as_fn(self.tcx(), ty_of_const(funcc)).unwrap();
-                let f = if let Some(inst) = try_resolve_function(
-                    self.tcx(),
-                    inst,
-                    TypingEnv::post_analysis(self.tcx(), leaf_loc.function),
-                    args,
-                ) {
-                    match handle_shims(inst, self.tcx(), param_env, weight.span) {
-                        ShimResult::IsHandledShim { instance, .. } => instance,
-                        ShimResult::IsNotShim => inst,
-                        ShimResult::IsNonHandleableShim => {
-                            self.ctx().maybe_span_err(
-                                weight.span,
-                                "SOUNDNESS: Cannot determine markers for shim usage",
-                            );
-                            return;
-                        }
-                    }
-                    .def_id()
-                } else {
-                    debug!("Could not resolve {inst:?} properly during marker assignment");
-                    inst
-                };
-
-                self.known_def_ids.extend(Some(f));
-
-                // Question: Could a function with no input produce an
-                // output that has aliases? E.g. could some place, where the
-                // local portion isn't the local from the destination of
-                // this function call be affected/modified by this call? If
-                // so, that location would also need to have this marker
-                // attached
-                //
-                // Also yikes. This should have better detection of whether
-                // a place is (part of) a function return
-                let mut in_edges = graph
-                    .graph
-                    .edges_directed(old_node, Direction::Incoming)
-                    .filter(|e| e.weight().kind == DepEdgeKind::Data);
-
-                let needs_return_markers = in_edges.clone().next().is_none()
-                    || in_edges.any(|e| {
-                        let at = e.weight().at;
-                        #[cfg(debug_assertions)]
-                        assert_edge_location_invariant(self.tcx(), at, body, weight.at, |cs| {
-                            cs.leaf()
-                        });
-                        weight.at == at && e.weight().target_use.is_return()
-                    });
-
-                if needs_return_markers {
-                    self.register_annotations_for_function(node, f, |ann| {
-                        ann.refinement.on_return()
-                    });
-                }
-
-                for e in graph.graph.edges_directed(old_node, Direction::Outgoing) {
-                    let SourceUse::Argument(arg) = e.weight().source_use else {
-                        continue;
-                    };
-                    self.register_annotations_for_function(node, f, |ann| {
-                        ann.refinement.on_argument().contains(arg as u32).unwrap()
-                    });
-                }
-            }
-            _ => (),
-        }
-    }
-
-    /// Reconstruct the type for the data this node represents.
-    fn determine_place_type(
-        &self,
-        at: CallString,
-        place: mir::PlaceRef<'tcx>,
-        span: rustc_span::Span,
-    ) -> Option<mir::tcx::PlaceTy<'tcx>> {
-        let tcx = self.tcx();
-        let locations = at.iter_from_root().collect::<Vec<_>>();
-        let (last, mut rest) = locations.split_last().unwrap();
-
-        if self.entrypoint_is_async() {
-            let (first, tail) = rest.split_first().unwrap();
-            // The body of a top-level `async` function binds a closure to the
-            // return place `_0`. Here we expect are looking at the statement
-            // that does this binding.
-            assert!(expect_stmt_at(self.body_cache(), *first).is_left());
-            rest = tail;
-        }
-
-        // So actually we're going to check the base place only, because
-        // Flowistry sometimes tracks subplaces instead but we want the marker
-        // from the base place.
-        let place = if self.entrypoint_is_async() && place.local.as_u32() == 1 && rest.len() == 1 {
-            if place.projection.is_empty() {
-                return None;
-            }
-            // in the case of targeting the top-level async closure (e.g. async args)
-            // we'll keep the first projection.
-            mir::Place {
-                local: place.local,
-                projection: self.tcx().mk_place_elems(&place.projection[..1]),
-            }
-        } else {
-            place.local.into()
-        };
-
-        let resolution = self.call_string_resolver.resolve(at);
-
-        // Thread through each caller to recover generic arguments
-        let body = self.body_cache().get(last.function);
-        let raw_ty = place.ty(body.body(), tcx);
-        Some(
-            try_monomorphize(
-                resolution,
-                tcx,
-                TypingEnv::fully_monomorphized(),
-                &raw_ty,
-                span,
-            )
-            .unwrap(),
-        )
-    }
-
-    /// Fetch annotations item identified by this `id`.
-    ///
-    /// The callback is used to filter out annotations where the "refinement"
-    /// doesn't match. The idea is that the caller of this function knows
-    /// whether they are looking for annotations on an argument or return of a
-    /// function identified by this `id` or on a type and the callback should be
-    /// used to enforce this.
-    fn register_annotations_for_function(
-        &mut self,
-        node: Node,
-        function: DefId,
-        mut filter: impl FnMut(&MarkerAnnotation) -> bool,
-    ) {
-        let parent = get_parent(self.tcx(), function);
-        let marker_ctx = self.marker_ctx().clone();
-        self.register_markers(
-            node,
-            marker_ctx
-                .combined_markers(function)
-                .chain(
-                    parent
-                        .into_iter()
-                        .flat_map(|parent| marker_ctx.combined_markers(parent)),
-                )
-                .filter(|ann| filter(ann))
-                .map(|ann| ann.marker),
-        );
-        self.known_def_ids.extend(parent);
-    }
-
-    /// Check if this node is of a marked type and register that type.
-    fn handle_node_types(&mut self, old_node: Node, weight: &DepNode<'tcx, CallString>) {
-        let i = self.new_node_for(old_node);
-
-        let Some(place_ty) =
-            self.determine_place_type(weight.at, weight.place.as_ref(), weight.span)
-        else {
-            return;
-        };
-        trace!("Node {:?} has place type {:?}", weight.place, place_ty);
-        // Restore after fixing https://github.com/brownsys/paralegal/issues/138
-        //let deep = !weight.is_split;
-        let deep = true;
-        let mut node_types = self.type_is_marked(place_ty, deep).collect::<HashSet<_>>();
-        for (p, _) in weight.place.iter_projections() {
-            if let Some(place_ty) = self.determine_place_type(weight.at, p, weight.span) {
-                node_types.extend(self.type_is_marked(place_ty, false));
-            }
-        }
-        self.known_def_ids.extend(node_types.iter().copied());
-        let tcx = self.tcx();
-        if !node_types.is_empty() {
-            self.types.entry(i).or_default().extend(
-                node_types
-                    .iter()
-                    .filter(|t| !tcx.is_coroutine(**t) && !tcx.def_kind(*t).is_fn_like()),
-            )
-        }
-        trace!(
-            "For node {:?} found marked node types {node_types:?}",
-            weight.place
-        );
-    }
-
-    /// Create an initial flowistry graph for the function identified by
-    /// `local_def_id`.
-    fn create_flowistry_graph(
-        generator: &SPDGGenerator<'tcx>,
-        local_def_id: LocalDefId,
-    ) -> Result<(DepGraph<'tcx>, SPDGStats)> {
-        let pdg = generator.pdg_constructor.construct_graph(local_def_id);
-
-        Ok((pdg, Default::default()))
-    }
-
-    /// Consume the generator and compile the [`SPDG`].
-    pub fn make_spdg(mut self) -> SPDG {
-        let start = Instant::now();
-        self.make_spdg_impl();
-        let arguments = self.determine_arguments();
-        let return_ = self.determine_return();
-        self.generator
-            .stats
-            .record_timed(TimedStat::Conversion, start.elapsed());
-        self.stats.conversion_time = start.elapsed();
-        SPDG {
-            path: path_for_item(self.def_id, self.tcx()),
-            graph: self.spdg,
-            id: self.def_id,
-            name: Identifier::new(self.target.name()),
-            arguments,
-            markers: self
-                .marker_assignments
-                .into_iter()
-                .map(|(k, v)| (k, v.into_iter().collect()))
-                .collect(),
-            return_,
-            type_assigns: self
-                .types
-                .into_iter()
-                .map(|(k, v)| (k, Types(v.into())))
-                .collect(),
-            statistics: self.stats,
-        }
-    }
-
-    fn body_cache(&self) -> &BodyCache<'tcx> {
-        self.generator.pdg_constructor.body_cache()
-    }
-
-    /// This initializes the fields `spdg` and `index_map` and should be called first
-    fn make_spdg_impl(&mut self) {
-        use petgraph::prelude::*;
-        let g_ref = self.dep_graph.clone();
-        let input = &g_ref.graph;
-        let tcx = self.tcx();
-
-        for (i, weight) in input.node_references() {
-            let at = weight.at.leaf();
-            let body = self.body_cache().get(at.function).body();
-
-            let node_span = body.local_decls[weight.place.local].source_info.span;
-            self.register_node(
-                i,
-                NodeInfo {
-                    at: weight.at,
-                    description: format!("{:?}", weight.place),
-                    span: src_loc_for_span(node_span, tcx),
-                    local: weight.place.local.as_u32(),
-                },
-            );
-            self.node_annotations(i, weight);
-
-            self.handle_node_types(i, weight);
-        }
-
-        for e in input.edge_references() {
-            let DepEdge {
-                kind,
-                at,
-                source_use,
-                target_use,
-            } = *e.weight();
-            self.spdg.add_edge(
-                self.new_node_for(e.source()),
-                self.new_node_for(e.target()),
-                EdgeInfo {
-                    at,
-                    kind: match kind {
-                        DepEdgeKind::Control => EdgeKind::Control,
-                        DepEdgeKind::Data => EdgeKind::Data,
-                    },
-                    source_use,
-                    target_use,
-                },
-            );
-        }
-    }
-
-    /// Return the (sub)types of this type that are marked.
-    fn type_is_marked(
-        &'a self,
-        typ: mir::tcx::PlaceTy<'tcx>,
-        deep: bool,
-    ) -> impl Iterator<Item = TypeId> + 'a {
-        if deep {
-            Either::Left(self.marker_ctx().deep_type_markers(typ.ty).iter().copied())
-        } else {
-            Either::Right(self.marker_ctx().shallow_type_markers(typ.ty))
-        }
-        .map(|(d, _)| d)
-    }
-
-    /// Similar to `CallString::is_at_root`, but takes into account top-level
-    /// async functions
-    fn try_as_root(&self, at: CallString) -> Option<GlobalLocation> {
-        if self.entrypoint_is_async() && at.len() == 2 {
-            at.iter_from_root().nth(1)
-        } else if at.is_at_root() {
-            Some(at.leaf())
-        } else {
-            None
-        }
-    }
-
-    /// Try to find the node corresponding to the values returned from this
-    /// controller.
-    ///
-    /// TODO: Include mutable inputs
-    fn determine_return(&self) -> Box<[Node]> {
-        // In async functions
-        self.spdg
-            .node_references()
-            .filter(|n| {
-                let weight = n.weight();
-                let at = weight.at;
-                matches!(self.try_as_root(at), Some(l) if l.location == RichLocation::End)
-            })
-            .map(|n| n.id())
-            .collect()
-    }
-
-    /// Determine the set if nodes corresponding to the inputs to the
-    /// entrypoint. The order is guaranteed to be the same as the source-level
-    /// function declaration.
-    fn determine_arguments(&self) -> Box<[Node]> {
-        let mut g_nodes: Vec<_> = self
-            .dep_graph
-            .graph
-            .node_references()
-            .filter(|n| {
-                let at = n.weight().at;
-                let is_candidate =
-                    matches!(self.try_as_root(at), Some(l) if l.location == RichLocation::Start);
-                is_candidate
-            })
-            .collect();
-
-        g_nodes.sort_by_key(|(_, i)| i.place.local);
-
-        g_nodes
-            .into_iter()
-            .map(|n| self.new_node_for(n.id()))
-            .collect()
-    }
-}
+use petgraph::visit::{IntoNodeReferences, NodeRef};
 
 fn dep_edge_kind_to_edge_kind(kind: DepEdgeKind) -> EdgeKind {
     match kind {
@@ -597,173 +70,6 @@ fn assert_edge_location_invariant<'tcx, Loc: Eq + std::fmt::Display>(
     msg.emit()
 }
 
-/// Find the statement at this location or fail.
-fn expect_stmt_at<'tcx>(
-    body_cache: &BodyCache<'tcx>,
-    loc: GlobalLocation,
-) -> Either<&'tcx mir::Statement<'tcx>, &'tcx mir::Terminator<'tcx>> {
-    let body = &body_cache.get(loc.function).body();
-    let RichLocation::Location(loc) = loc.location else {
-        unreachable!();
-    };
-    body.stmt_at(loc)
-}
-
-/// If `did` is a method of an `impl` of a trait, then return the `DefId` that
-/// refers to the method on the trait definition.
-fn get_parent(tcx: TyCtxt, did: DefId) -> Option<DefId> {
-    let ident = tcx.opt_item_ident(did)?;
-    let kind = match tcx.def_kind(did) {
-        kind if kind.is_fn_like() => ty::AssocKind::Fn,
-        // todo allow constants and types also
-        _ => return None,
-    };
-    let r#impl = tcx.impl_of_method(did)?;
-    let r#trait = tcx.trait_id_of_impl(r#impl)?;
-    let id = tcx
-        .associated_items(r#trait)
-        .find_by_name_and_kind(tcx, ident, kind, r#trait)?
-        .def_id;
-    Some(id)
-}
-
-fn entrypoint_is_async<'tcx>(
-    body_cache: &BodyCache<'tcx>,
-    tcx: TyCtxt<'tcx>,
-    def_id: DefId,
-) -> bool {
-    tcx.asyncness(def_id).is_async()
-        || is_async_trait_fn(tcx, def_id, body_cache.get(def_id).body())
-}
-
-mod call_string_resolver {
-    //! Resolution of [`CallString`]s to [`FnResolution`]s.
-    //!
-    //! This is a separate mod so that we can use encapsulation to preserve the
-    //! internal invariants of the resolver.
-
-    use flowistry_pdg::CallString;
-    use flowistry_pdg_construction::utils::{
-        manufacture_substs_for, try_monomorphize, try_resolve_function,
-    };
-    use paralegal_spdg::Endpoint;
-    use rustc_middle::{
-        mir::TerminatorKind,
-        ty::{Instance, TypingEnv},
-    };
-    use rustc_utils::cache::Cache;
-
-    use crate::{Either, Pctx};
-
-    use super::{func_of_term, map_either, match_async_trait_assign, AsFnAndArgs};
-
-    /// Cached resolution of [`CallString`]s to [`Instance`]s.
-    ///
-    /// Only valid for a single controller. Each controller should initialize a
-    /// new resolver.
-    pub struct CallStringResolver<'tcx> {
-        cache: Cache<CallString, Instance<'tcx>>,
-        ctx: Pctx<'tcx>,
-        entrypoint_is_async: bool,
-    }
-
-    impl<'tcx> CallStringResolver<'tcx> {
-        /// Tries to resolve to the monomophized function in which this call
-        /// site exists. That is to say that `return.def_id() ==
-        /// cs.leaf().function`.
-        ///
-        /// Unlike `Self::resolve_internal` this can be called on any valid
-        /// [`CallString`].
-        pub fn resolve(&self, cs: CallString) -> Instance<'tcx> {
-            let tcx = self.ctx.tcx();
-            let (this, opt_prior_loc) = cs.pop();
-            if let Some(prior_loc) = opt_prior_loc {
-                if prior_loc.len() != 1 || !self.entrypoint_is_async {
-                    return self.resolve_internal(prior_loc);
-                }
-            }
-            let def_id = this.function;
-            try_resolve_function(
-                tcx,
-                def_id,
-                TypingEnv::post_analysis(tcx, def_id).with_post_analysis_normalized(tcx),
-                manufacture_substs_for(tcx, def_id).unwrap(),
-            )
-            .unwrap()
-        }
-
-        pub fn new(ctx: Pctx<'tcx>, entrypoint: Endpoint) -> Self {
-            Self {
-                cache: Default::default(),
-                entrypoint_is_async: super::entrypoint_is_async(
-                    ctx.body_cache(),
-                    ctx.tcx(),
-                    entrypoint,
-                ),
-                ctx,
-            }
-        }
-
-        /// This resolves the monomorphized function *being called at* this call
-        /// site.
-        ///
-        /// This function is internal because it panics if `cs.leaf().location`
-        /// is not either a function call or a statement where an async closure
-        /// is created and assigned.
-        fn resolve_internal(&self, cs: CallString) -> Instance<'tcx> {
-            *self.cache.get(&cs, |_| {
-                let this = cs.leaf();
-                let prior = self.resolve(cs);
-
-                let tcx = self.ctx.tcx();
-
-                let base_stmt = super::expect_stmt_at(self.ctx.body_cache(), this);
-                let param_env = TypingEnv::post_analysis(tcx, prior.def_id())
-                    .with_post_analysis_normalized(tcx);
-                let normalized = map_either(
-                    base_stmt,
-                    |stmt| {
-                        try_monomorphize(prior, tcx, param_env, stmt, stmt.source_info.span)
-                            .unwrap()
-                    },
-                    |term| {
-                        try_monomorphize(prior, tcx, param_env, term, term.source_info.span)
-                            .unwrap()
-                    },
-                );
-                let res = match normalized {
-                    Either::Right(term) => {
-                        let (def_id, args) = func_of_term(tcx, &term).unwrap();
-                        let instance = Instance::expect_resolve(
-                            tcx,
-                            param_env,
-                            def_id,
-                            args,
-                            term.source_info.span,
-                        );
-                        if let Some(model) = self.ctx.marker_ctx().has_stub(def_id) {
-                            let TerminatorKind::Call { args, .. } = &term.kind else {
-                                unreachable!()
-                            };
-                            model
-                                .apply(tcx, instance, param_env, args, term.source_info.span)
-                                .unwrap()
-                                .0
-                        } else {
-                            term.as_instance_and_args(tcx).unwrap().0
-                        }
-                    }
-                    Either::Left(stmt) => {
-                        let (def_id, generics) = match_async_trait_assign(&stmt).unwrap();
-                        try_resolve_function(tcx, def_id, param_env, generics).unwrap()
-                    }
-                };
-                res
-            })
-        }
-    }
-}
-
 struct GraphAssembler<'tcx, 'a> {
     def_id: DefId,
     graph: SPDGImpl,
@@ -781,8 +87,8 @@ struct GraphAssembler<'tcx, 'a> {
     nodes: Vec<Vec<GNode>>,
 }
 
-pub fn assemble_pdg<'tcx, 'a>(
-    generator: &'a SPDGGenerator<'tcx>,
+pub fn assemble_pdg<'a>(
+    generator: &'a SPDGGenerator<'_>,
     known_def_ids: &'a mut FxHashSet<DefId>,
     target: &'a FnToAnalyze,
 ) -> SPDG {
@@ -882,7 +188,7 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         let table = self.nodes.last_mut().unwrap();
         let prior = table[node.index()];
         if GNode(Node::end()) != prior {
-            return prior;
+            prior
         } else {
             let my_idx = GNode(self.graph.add_node(weight));
             table[node.index()] = my_idx;
@@ -921,7 +227,6 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
     where
         F: FnOnce(&mut Self, &mut VisitDriver<'tcx, 'c, K>) -> R,
     {
-        let g = vis.current_graph_as_rc();
         let new_ctrl_inputs: Box<[(GNode, EdgeInfo)]> = new_ctrl_inputs
             .iter()
             .map(|(node, edge)| {
@@ -1129,107 +434,117 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
                     ann.refinement.on_return()
                 });
             }
-            RichLocation::Location(loc) => {
-                let crate::Either::Right(
-                    term @ mir::Terminator {
-                        kind: mir::TerminatorKind::Call { func, .. },
-                        ..
-                    },
-                ) = body.stmt_at(loc)
-                else {
-                    return;
-                };
-                debug!("Assigning markers to {:?}", term.kind);
-                let res = function;
-                let param_env = TypingEnv::post_analysis(self.tcx(), res.def_id());
-                let func =
-                    try_monomorphize(res, self.tcx(), param_env, func, term.source_info.span)
-                        .unwrap();
-                let Some(funcc) = func.constant() else {
-                    self.generator.ctx.maybe_span_err(
+            RichLocation::Location(loc) => self.handle_node_annotations_for_regular_location(
+                local_node, node, weight, body, loc, vis,
+            ),
+            _ => (),
+        }
+    }
+
+    fn handle_node_annotations_for_regular_location<K: Clone>(
+        &mut self,
+        local_node: Node,
+        node: GNode,
+        weight: &DepNode<'tcx, OneHopLocation>,
+        body: &mir::Body<'tcx>,
+        loc: Location,
+        vis: &VisitDriver<'tcx, '_, K>,
+    ) {
+        let function = vis.current_function();
+        let function_id = function.def_id();
+        let crate::Either::Right(
+            term @ mir::Terminator {
+                kind: mir::TerminatorKind::Call { func, .. },
+                ..
+            },
+        ) = body.stmt_at(loc)
+        else {
+            return;
+        };
+        debug!("Assigning markers to {:?}", term.kind);
+        let param_env = TypingEnv::post_analysis(self.tcx(), function.def_id());
+        let func =
+            try_monomorphize(function, self.tcx(), param_env, func, term.source_info.span).unwrap();
+        let Some(funcc) = func.constant() else {
+            self.generator.ctx.maybe_span_err(
+                weight.span,
+                "SOUNDNESS: Cannot determine markers for function call",
+            );
+            return;
+        };
+        let (inst, args) = type_as_fn(self.tcx(), ty_of_const(funcc)).unwrap();
+        let f = if let Some(inst) = try_resolve_function(
+            self.tcx(),
+            inst,
+            TypingEnv::post_analysis(self.tcx(), function_id),
+            args,
+        ) {
+            match handle_shims(inst, self.tcx(), param_env, weight.span) {
+                ShimResult::IsHandledShim { instance, .. } => instance,
+                ShimResult::IsNotShim => inst,
+                ShimResult::IsNonHandleableShim => {
+                    self.ctx().maybe_span_err(
                         weight.span,
-                        "SOUNDNESS: Cannot determine markers for function call",
+                        "SOUNDNESS: Cannot determine markers for shim usage",
                     );
                     return;
-                };
-                let (inst, args) = type_as_fn(self.tcx(), ty_of_const(funcc)).unwrap();
-                let f = if let Some(inst) = try_resolve_function(
-                    self.tcx(),
-                    inst,
-                    TypingEnv::post_analysis(self.tcx(), function_id),
-                    args,
-                ) {
-                    match handle_shims(inst, self.tcx(), param_env, weight.span) {
-                        ShimResult::IsHandledShim { instance, .. } => instance,
-                        ShimResult::IsNotShim => inst,
-                        ShimResult::IsNonHandleableShim => {
-                            self.ctx().maybe_span_err(
-                                weight.span,
-                                "SOUNDNESS: Cannot determine markers for shim usage",
-                            );
-                            return;
-                        }
-                    }
-                    .def_id()
-                } else {
-                    debug!("Could not resolve {inst:?} properly during marker assignment");
-                    inst
-                };
-
-                self.known_def_ids.extend(Some(f));
-
-                let graph = vis.current_graph();
-
-                // Question: Could a function with no input produce an
-                // output that has aliases? E.g. could some place, where the
-                // local portion isn't the local from the destination of
-                // this function call be affected/modified by this call? If
-                // so, that location would also need to have this marker
-                // attached
-                //
-                // Also yikes. This should have better detection of whether
-                // a place is (part of) a function return
-
-                let mut is_return_use = false;
-                let mut has_no_data_edges = true;
-
-                for eref in graph.raw().edges_directed(local_node, petgraph::Outgoing) {
-                    let SourceUse::Argument(arg) = eref.weight().source_use else {
-                        continue;
-                    };
-                    self.register_annotations_for_function(node, f, |ann| {
-                        ann.refinement.on_argument().contains(arg as u32).unwrap()
-                    });
-                }
-                for eref in graph.raw().edges_directed(local_node, petgraph::Incoming) {
-                    if eref.weight().kind == DepEdgeKind::Data {
-                        has_no_data_edges = false;
-                        let at = eref.weight().at.clone();
-                        // #[cfg(debug_assertions)]
-                        // assert_edge_location_invariant(
-                        //     self.tcx(),
-                        //     at.clone(),
-                        //     body,
-                        //     weight.at.clone(),
-                        //     |at| GlobalLocation {
-                        //         function: function.def_id(),
-                        //         location: at.location,
-                        //     },
-                        // );
-                        if weight.at == at && eref.weight().target_use.is_return() {
-                            is_return_use = true;
-                        }
-                    }
-                }
-                let needs_return_markers = has_no_data_edges | is_return_use;
-
-                if needs_return_markers {
-                    self.register_annotations_for_function(node, f, |ann| {
-                        ann.refinement.on_return()
-                    });
                 }
             }
-            _ => (),
+            .def_id()
+        } else {
+            debug!("Could not resolve {inst:?} properly during marker assignment");
+            inst
+        };
+
+        self.known_def_ids.extend(Some(f));
+
+        let graph = vis.current_graph();
+
+        // Question: Could a function with no input produce an
+        // output that has aliases? E.g. could some place, where the
+        // local portion isn't the local from the destination of
+        // this function call be affected/modified by this call? If
+        // so, that location would also need to have this marker
+        // attached
+        //
+        // Also yikes. This should have better detection of whether
+        // a place is (part of) a function return
+
+        let mut is_return_use = false;
+        let mut has_no_data_edges = true;
+
+        for eref in graph.raw().edges_directed(local_node, petgraph::Outgoing) {
+            let SourceUse::Argument(arg) = eref.weight().source_use else {
+                continue;
+            };
+            self.register_annotations_for_function(node, f, |ann| {
+                ann.refinement.on_argument().contains(arg as u32).unwrap()
+            });
+        }
+        for eref in graph.raw().edges_directed(local_node, petgraph::Incoming) {
+            if eref.weight().kind == DepEdgeKind::Data {
+                has_no_data_edges = false;
+                let at = eref.weight().at.clone();
+                #[cfg(debug_assertions)]
+                assert_edge_location_invariant(
+                    self.tcx(),
+                    at.clone(),
+                    body,
+                    weight.at.clone(),
+                    |at| GlobalLocation {
+                        function: function.def_id(),
+                        location: at.location,
+                    },
+                );
+                if weight.at == at && eref.weight().target_use.is_return() {
+                    is_return_use = true;
+                }
+            }
+        }
+        let needs_return_markers = has_no_data_edges | is_return_use;
+
+        if needs_return_markers {
+            self.register_annotations_for_function(node, f, |ann| ann.refinement.on_return());
         }
     }
 
@@ -1422,7 +737,7 @@ impl GNode {
     }
 }
 
-impl<'tcx, 'a, K: std::hash::Hash + Eq + Clone> Visitor<'tcx, K> for GraphAssembler<'tcx, 'a> {
+impl<'tcx, K: std::hash::Hash + Eq + Clone> Visitor<'tcx, K> for GraphAssembler<'tcx, '_> {
     fn visit_inlined_call(
         &mut self,
         vis: &mut VisitDriver<'tcx, '_, K>,

--- a/crates/paralegal-flow/src/ana/graph_converter.rs
+++ b/crates/paralegal-flow/src/ana/graph_converter.rs
@@ -1326,32 +1326,21 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         );
         for (nidx, n) in pgraph.iter_nodes() {
             let generator_loc = RichLocation::Location(loc);
-            let relocated_n = |slf: &mut Self, vis, start_or_end| {
-                slf.add_node(
-                    nidx,
-                    vis,
-                    &n.map_at(|_| OneHopLocation {
-                        location: generator_loc,
-                        in_child: Some((generator.def_id(), start_or_end)),
-                    }),
-                )
-            };
 
-            if n.place.local.as_u32() != 1 && n.at.location == RichLocation::Start {
+            if n.place.local.as_u32() == 1 && n.at.location == RichLocation::Start {
+                let ridx = self.translate_node(nidx);
                 let Some(mir::ProjectionElem::Field(id, _)) = n.place.projection.first() else {
                     tcx.dcx().span_err(
                         n.span,
-                        "Expected field projection on async generator in {def_id:?}",
+                        format!("Expected field projection on async generator in {def_id:?}, found {:?}", n.place),
                     );
                     continue;
                 };
 
                 let arg = args_as_nodes[id.as_usize()];
-                assert!(false, "TODO remap location of n");
-                let ridx = relocated_n(self, driver, false).to_index();
                 self.graph.add_edge(
                     arg.to_index(),
-                    ridx,
+                    ridx.to_index(),
                     globalize_edge(
                         driver,
                         &DepEdge {
@@ -1366,9 +1355,9 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
                     ),
                 );
             } else if n.place.local == mir::RETURN_PLACE {
-                let ridx = relocated_n(self, driver, true).to_index();
+                let ridx = self.translate_node(nidx);
                 self.graph.add_edge(
-                    ridx,
+                    ridx.to_index(),
                     return_node.to_index(),
                     globalize_edge(
                         driver,
@@ -1396,7 +1385,11 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
     fn with_new_translation_table<R>(&mut self, size: usize, f: impl FnOnce(&mut Self) -> R) -> R {
         self.nodes.push(vec![GNode(Node::end()); size]);
         let result = f(self);
-        assert_eq!(self.nodes.pop().unwrap().len(), size);
+        if self.nodes.len() != 1 {
+            // Yuck. In oder to still be able to fix up the async args we let
+            // the bottom translation table remain.
+            assert_eq!(self.nodes.pop().unwrap().len(), size);
+        }
         result
     }
 }

--- a/crates/paralegal-flow/src/ana/graph_converter.rs
+++ b/crates/paralegal-flow/src/ana/graph_converter.rs
@@ -11,7 +11,9 @@ use flowistry_pdg_construction::{
     body_cache::BodyCache,
     call_tree_visit::{VisitDriver, Visitor},
     determine_async,
-    graph::{DepEdge, DepEdgeKind, DepGraph, DepNode, OneHopLocation, PartialGraph},
+    graph::{
+        DepEdge, DepEdgeKind, DepGraph, DepNode, GraphConnectionPoint, OneHopLocation, PartialGraph,
+    },
     is_async_trait_fn, match_async_trait_assign,
     utils::{handle_shims, try_monomorphize, try_resolve_function, type_as_fn, ShimResult},
 };
@@ -767,13 +769,13 @@ struct GraphAssembler<'tcx, 'a> {
     graph: SPDGImpl,
     // nodes: FxHashMap<DepNode<'tcx, CallString>, petgraph::graph::NodeIndex>,
     // control_inputs: Box<[(NodeIndex, DepEdge<CallString>)]>,
-    nodes: FxHashMap<NodeInfo, petgraph::graph::NodeIndex>,
-    control_inputs: Box<[(Node, EdgeInfo)]>,
-    marker_assignments: HashMap<Node, HashSet<Identifier>>,
+    nodes: FxHashMap<(Node, CallString), GNode>,
+    control_inputs: Box<[(GNode, EdgeInfo)]>,
+    marker_assignments: HashMap<GNode, HashSet<Identifier>>,
     known_def_ids: &'a mut FxHashSet<DefId>,
     /// A map of which nodes are of which (marked) type. We build this up during
     /// conversion.
-    types: HashMap<Node, Vec<DefId>>,
+    types: HashMap<GNode, Vec<DefId>>,
     generator: &'a SPDGGenerator<'tcx>,
 }
 
@@ -826,14 +828,14 @@ pub fn assemble_pdg<'tcx, 'a>(
         markers: assembler
             .marker_assignments
             .into_iter()
-            .map(|(node, markers)| (node, markers.into_iter().collect()))
+            .map(|(GNode(node), markers)| (node, markers.into_iter().collect()))
             .collect(),
         arguments,
         return_,
         type_assigns: assembler
             .types
             .into_iter()
-            .map(|(k, v)| (k, Types(v.into())))
+            .map(|(GNode(k), v)| (k, Types(v.into())))
             .collect(),
         statistics: Default::default(),
     }
@@ -857,7 +859,7 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         }
     }
 
-    fn register_markers(&mut self, node: Node, markers: impl IntoIterator<Item = Identifier>) {
+    fn register_markers(&mut self, node: GNode, markers: impl IntoIterator<Item = Identifier>) {
         let mut markers = markers.into_iter().peekable();
 
         if markers.peek().is_some() {
@@ -868,16 +870,31 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         }
     }
 
-    fn add_node(&mut self, node: NodeInfo) -> petgraph::graph::NodeIndex {
-        let mut was_added = false;
-        let idx = *self.nodes.entry(node.clone()).or_insert_with(|| {
-            was_added = true;
-            self.graph.add_node(node.clone())
-        });
-        if was_added {
-            trace!("Added new node {idx:?} for {node}");
-        }
-        idx
+    fn add_node<K: Clone>(
+        &mut self,
+        node: Node,
+        vis: &mut VisitDriver<'tcx, '_, K>,
+        weight: &DepNode<'tcx, OneHopLocation>,
+    ) -> GNode {
+        let weight = globalize_node(vis, weight, self.tcx());
+        let cs = weight.at;
+        let my_idx = GNode(self.graph.add_node(weight));
+        self.nodes.insert((node, cs), my_idx);
+        my_idx
+    }
+
+    fn add_untranslatable_node(
+        &mut self,
+        place: mir::Place,
+        at: CallString,
+        span: rustc_span::Span,
+    ) -> GNode {
+        GNode(self.graph.add_node(NodeInfo {
+            at,
+            description: format!("{place:?}"),
+            span: src_loc_for_span(span, self.tcx()),
+            local: place.local.as_u32(),
+        }))
     }
 
     /// Forwarding of control flow. It is sound to replace the control inputs
@@ -891,18 +908,18 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
     fn with_new_ctr_inputs<'c, F, R, K: Clone>(
         &mut self,
         vis: &mut VisitDriver<'tcx, 'c, K>,
-        new_ctrl_inputs: &[(DepNode<'tcx, OneHopLocation>, DepEdge<OneHopLocation>)],
+        new_ctrl_inputs: &[GraphConnectionPoint<'tcx>],
         f: F,
     ) -> R
     where
         F: FnOnce(&mut Self, &mut VisitDriver<'tcx, 'c, K>) -> R,
     {
-        let new_ctrl_inputs: Box<[(Node, EdgeInfo)]> = new_ctrl_inputs
+        let g = vis.current_graph_as_rc();
+        let new_ctrl_inputs: Box<[(GNode, EdgeInfo)]> = new_ctrl_inputs
             .iter()
-            .map(|(src, edge)| {
-                let src = globalize_node(vis, src, self.tcx());
-                trace!("in control input forwarding");
-                let src_idx = self.add_node(src);
+            .map(|(node, edge)| {
+                let cs = vis.globalize_location(&g.node_props(*node).at);
+                let src_idx = self.translate_node(*node, cs).unwrap();
                 let new_edge = globalize_edge(vis, edge);
                 (src_idx, new_edge)
             })
@@ -942,7 +959,7 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
     /// used to enforce this.
     fn register_annotations_for_function(
         &mut self,
-        node: Node,
+        node: GNode,
         function: DefId,
         mut filter: impl FnMut(&MarkerAnnotation) -> bool,
     ) {
@@ -966,12 +983,10 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
     /// Check if this node is of a marked type and register that type.
     fn handle_node_types<K: Clone>(
         &mut self,
-        node: Node,
+        node: GNode,
         weight: &DepNode<'tcx, OneHopLocation>,
         vis: &VisitDriver<'tcx, '_, K>,
     ) {
-        let i = node;
-
         trace!("Checking types for node {node:?} ({:?})", weight.place);
 
         let Some(place_ty) =
@@ -992,7 +1007,7 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         self.known_def_ids.extend(node_types.iter().copied());
         let tcx = self.tcx();
         if !node_types.is_empty() {
-            self.types.entry(i).or_default().extend(
+            self.types.entry(node).or_default().extend(
                 node_types
                     .iter()
                     .filter(|t| !tcx.is_coroutine(**t) && !tcx.def_kind(*t).is_fn_like()),
@@ -1071,7 +1086,7 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
 
     fn node_annotations<K: Clone>(
         &mut self,
-        node: Node,
+        node: GNode,
         weight: &DepNode<'tcx, OneHopLocation>,
         vis: &VisitDriver<'tcx, '_, K>,
     ) {
@@ -1082,6 +1097,7 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         let leaf_loc = weight.at.location;
         let function = vis.current_function();
         let function_id = function.def_id();
+        let cs = self.graph.node_weight(node.to_index()).unwrap().at;
 
         let body = self
             .generator
@@ -1172,14 +1188,16 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
                 let mut has_no_data_edges = true;
 
                 for (from, to, edge_weight) in graph.iter_edges() {
-                    if from == weight {
+                    let from = self.translate_node(from, cs).unwrap();
+                    let to = self.translate_node(to, cs).unwrap();
+                    if from == node {
                         let SourceUse::Argument(arg) = edge_weight.source_use else {
                             continue;
                         };
                         self.register_annotations_for_function(node, f, |ann| {
                             ann.refinement.on_argument().contains(arg as u32).unwrap()
                         });
-                    } else if to == weight && edge_weight.kind == DepEdgeKind::Data {
+                    } else if to == node && edge_weight.kind == DepEdgeKind::Data {
                         has_no_data_edges = false;
                         let at = edge_weight.at.clone();
                         #[cfg(debug_assertions)]
@@ -1289,37 +1307,29 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         let args_as_nodes = base_body
             .args_iter()
             .map(|arg| {
-                DepNode::new(
+                self.add_untranslatable_node(
                     arg.into(),
-                    OneHopLocation {
-                        location: RichLocation::Start,
-                        in_child: None,
-                    },
-                    tcx,
-                    base_body,
-                    def_id,
-                    false,
+                    driver.globalize_location(&RichLocation::Start.into()),
+                    base_body.local_decls[arg].source_info.span,
                 )
             })
             .collect::<Vec<_>>();
-        let return_node = DepNode::new(
+        let return_node = self.add_untranslatable_node(
             mir::RETURN_PLACE.into(),
-            OneHopLocation {
-                location: RichLocation::End,
-                in_child: None,
-            },
-            tcx,
-            base_body,
-            def_id,
-            false,
+            driver.globalize_location(&RichLocation::End.into()),
+            base_body.local_decls[mir::RETURN_PLACE].source_info.span,
         );
-        for n in pgraph.iter_nodes() {
+        for (nidx, n) in pgraph.iter_nodes() {
             let generator_loc = RichLocation::Location(loc);
-            let relocated_n = |start_or_end| {
-                n.map_at(|_| OneHopLocation {
-                    location: generator_loc,
-                    in_child: Some((generator.def_id(), start_or_end)),
-                })
+            let relocated_n = |slf: &mut Self, vis, start_or_end| {
+                slf.add_node(
+                    nidx,
+                    vis,
+                    &n.map_at(|_| OneHopLocation {
+                        location: generator_loc,
+                        in_child: Some((generator.def_id(), start_or_end)),
+                    }),
+                )
             };
 
             if n.place.local.as_u32() != 1 && n.at.location == RichLocation::Start {
@@ -1331,39 +1341,49 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
                     continue;
                 };
 
-                let arg = &args_as_nodes[id.as_usize()];
+                let arg = args_as_nodes[id.as_usize()];
                 assert!(false, "TODO remap location of n");
-                self.visit_edge(
-                    driver,
-                    arg,
-                    &relocated_n(true),
-                    &DepEdge {
-                        kind: DepEdgeKind::Data,
-                        at: OneHopLocation {
-                            location: generator_loc,
-                            in_child: None,
+                let ridx = relocated_n(self, driver, false).to_index();
+                self.graph.add_edge(
+                    arg.to_index(),
+                    ridx,
+                    globalize_edge(
+                        driver,
+                        &DepEdge {
+                            kind: DepEdgeKind::Data,
+                            at: OneHopLocation {
+                                location: generator_loc,
+                                in_child: None,
+                            },
+                            source_use: SourceUse::Argument(id.as_u32() as u8),
+                            target_use: TargetUse::Assign,
                         },
-                        source_use: SourceUse::Argument(id.as_u32() as u8),
-                        target_use: TargetUse::Assign,
-                    },
+                    ),
                 );
             } else if n.place.local == mir::RETURN_PLACE {
-                self.visit_edge(
-                    driver,
-                    &relocated_n(true),
-                    &return_node,
-                    &DepEdge {
-                        kind: DepEdgeKind::Data,
-                        at: OneHopLocation {
-                            location: generator_loc,
-                            in_child: None,
+                let ridx = relocated_n(self, driver, true).to_index();
+                self.graph.add_edge(
+                    ridx,
+                    return_node.to_index(),
+                    globalize_edge(
+                        driver,
+                        &DepEdge {
+                            kind: DepEdgeKind::Data,
+                            at: OneHopLocation {
+                                location: generator_loc,
+                                in_child: None,
+                            },
+                            source_use: SourceUse::Operand,
+                            target_use: TargetUse::Return,
                         },
-                        source_use: SourceUse::Operand,
-                        target_use: TargetUse::Return,
-                    },
+                    ),
                 );
             }
         }
+    }
+
+    fn translate_node(&self, node: Node, cs: CallString) -> Option<GNode> {
+        self.nodes.get(&(node, cs)).cloned()
     }
 }
 
@@ -1394,6 +1414,16 @@ fn globalize_edge<K: Clone>(
     }
 }
 
+/// A newtype for indices into the global graph
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct GNode(petgraph::graph::NodeIndex);
+
+impl GNode {
+    fn to_index(self) -> petgraph::graph::NodeIndex {
+        self.0
+    }
+}
+
 impl<'tcx, 'a, K: std::hash::Hash + Eq + Clone> Visitor<'tcx, K> for GraphAssembler<'tcx, 'a> {
     fn visit_inlined_call(
         &mut self,
@@ -1401,7 +1431,7 @@ impl<'tcx, 'a, K: std::hash::Hash + Eq + Clone> Visitor<'tcx, K> for GraphAssemb
         loc: Location,
         inst: Instance<'tcx>,
         k: &K,
-        ctrl_inputs: &[(DepNode<'tcx, OneHopLocation>, DepEdge<OneHopLocation>)],
+        ctrl_inputs: &[GraphConnectionPoint<'tcx>],
     ) {
         self.with_new_ctr_inputs(vis, ctrl_inputs, |slf, vis| {
             vis.visit_inlined_call(slf, loc, inst, k)
@@ -1411,9 +1441,10 @@ impl<'tcx, 'a, K: std::hash::Hash + Eq + Clone> Visitor<'tcx, K> for GraphAssemb
     fn visit_node(
         &mut self,
         vis: &mut VisitDriver<'tcx, '_, K>,
+        k: Node,
         node: &DepNode<'tcx, OneHopLocation>,
     ) {
-        let idx = self.add_node(globalize_node(vis, node, self.tcx()));
+        let idx = self.add_node(k, vis, node);
         self.node_annotations(idx, node, vis);
         self.handle_node_types(idx, node, vis);
     }
@@ -1421,17 +1452,16 @@ impl<'tcx, 'a, K: std::hash::Hash + Eq + Clone> Visitor<'tcx, K> for GraphAssemb
     fn visit_edge(
         &mut self,
         vis: &mut VisitDriver<'tcx, '_, K>,
-        src: &DepNode<'tcx, OneHopLocation>,
-        dst: &DepNode<'tcx, OneHopLocation>,
+        src: Node,
+        dst: Node,
         kind: &DepEdge<OneHopLocation>,
     ) {
-        trace!("In visit edge");
-        let src = globalize_node(vis, src, self.tcx());
-        let src_idx = self.add_node(src);
-        let dst = globalize_node(vis, dst, self.tcx());
-        let dst_idx = self.add_node(dst);
+        let at = vis.globalize_location(&kind.at);
+        let src = self.translate_node(src, at).unwrap();
+        let dst = self.translate_node(dst, at).unwrap();
         let new_kind = globalize_edge(vis, kind);
-        self.graph.add_edge(src_idx, dst_idx, new_kind);
+        self.graph
+            .add_edge(src.to_index(), dst.to_index(), new_kind);
     }
 
     fn visit_partial_graph(
@@ -1452,18 +1482,17 @@ impl<'tcx, 'a, K: std::hash::Hash + Eq + Clone> Visitor<'tcx, K> for GraphAssemb
         // potential control inputs of the node. We could have the visitor use
         // an opposite ordering, but that is counterintuitive to other potential
         // users of the visitor.
-        for node in graph.iter_nodes() {
-            let new_node = globalize_node(vis, node, self.tcx());
-            trace!("In control assignment loop");
-            let node = self.add_node(new_node);
-
-            if !self
-                .graph
+        for (node, node_weight) in graph.iter_nodes() {
+            if !graph
+                .raw()
                 .edges_directed(node, petgraph::Direction::Incoming)
                 .any(|e| e.weight().is_control())
             {
+                let at = vis.globalize_location(&node_weight.at);
+                let local_node = self.translate_node(node, at).unwrap();
                 for (src, edge) in self.control_inputs.iter() {
-                    self.graph.add_edge(*src, node, edge.clone());
+                    self.graph
+                        .add_edge(src.to_index(), local_node.to_index(), edge.clone());
                 }
             }
         }

--- a/crates/paralegal-flow/src/ana/graph_converter.rs
+++ b/crates/paralegal-flow/src/ana/graph_converter.rs
@@ -369,12 +369,12 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         projections: &[mir::PlaceElem<'tcx>],
     ) {
         trace!("Has place type {base_ty:?}");
-        let deep = true;
-        let mut node_types = self.type_is_marked(base_ty, deep).collect::<HashSet<_>>();
+        let mut node_types = HashSet::new();
         for proj in projections {
-            base_ty = base_ty.projection_ty(self.tcx(), *proj);
             node_types.extend(self.type_is_marked(base_ty, false));
+            base_ty = base_ty.projection_ty(self.tcx(), *proj);
         }
+        node_types.extend(self.type_is_marked(base_ty, true));
         self.known_def_ids.extend(node_types.iter().copied());
         let tcx = self.tcx();
         if !node_types.is_empty() {

--- a/crates/paralegal-flow/src/ana/graph_converter.rs
+++ b/crates/paralegal-flow/src/ana/graph_converter.rs
@@ -809,88 +809,9 @@ pub fn assemble_pdg<'tcx, 'a>(
             },
             |driver| {
                 driver.start(&mut assembler);
-                let pgraph = driver.current_graph_as_rc();
-                let args_as_nodes = base_body
-                    .args_iter()
-                    .map(|arg| {
-                        DepNode::new(
-                            arg.into(),
-                            OneHopLocation {
-                                location: RichLocation::Start,
-                                in_child: None,
-                            },
-                            tcx,
-                            base_body,
-                            def_id,
-                            false,
-                        )
-                    })
-                    .collect::<Vec<_>>();
-                let return_node = DepNode::new(
-                    mir::RETURN_PLACE.into(),
-                    OneHopLocation {
-                        location: RichLocation::End,
-                        in_child: None,
-                    },
-                    tcx,
-                    base_body,
-                    def_id,
-                    false,
-                );
-                for n in pgraph.iter_nodes() {
-                    let generator_loc = RichLocation::Location(loc);
-                    let relocated_n = |start_or_end| {
-                        n.map_at(|_| OneHopLocation {
-                            location: generator_loc,
-                            in_child: Some((generator.def_id(), start_or_end)),
-                        })
-                    };
-
-                    if n.place.local.as_u32() != 1 && n.at.location == RichLocation::Start {
-                        let Some(mir::ProjectionElem::Field(id, _)) = n.place.projection.first()
-                        else {
-                            tcx.dcx().span_err(
-                                n.span,
-                                "Expected field projection on async generator in {def_id:?}",
-                            );
-                            continue;
-                        };
-
-                        let arg = &args_as_nodes[id.as_usize()];
-                        assert!(false, "TODO remap location of n");
-                        assembler.visit_edge(
-                            driver,
-                            arg,
-                            &relocated_n(true),
-                            &DepEdge {
-                                kind: DepEdgeKind::Data,
-                                at: OneHopLocation {
-                                    location: generator_loc,
-                                    in_child: None,
-                                },
-                                source_use: SourceUse::Argument(id.as_u32() as u8),
-                                target_use: TargetUse::Assign,
-                            },
-                        );
-                    } else if n.place.local == mir::RETURN_PLACE {
-                        assembler.visit_edge(
-                            driver,
-                            &relocated_n(true),
-                            &return_node,
-                            &DepEdge {
-                                kind: DepEdgeKind::Data,
-                                at: OneHopLocation {
-                                    location: generator_loc,
-                                    in_child: None,
-                                },
-                                source_use: SourceUse::Operand,
-                                target_use: TargetUse::Return,
-                            },
-                        );
-                    }
-                }
             },
         );
+        assembler.fix_async_args(def_id, generator, loc, &mut driver);
     } else {
         driver.start(&mut assembler);
     }
@@ -948,10 +869,15 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
     }
 
     fn add_node(&mut self, node: NodeInfo) -> petgraph::graph::NodeIndex {
-        *self
-            .nodes
-            .entry(node.clone())
-            .or_insert_with(|| self.graph.add_node(node))
+        let mut was_added = false;
+        let idx = *self.nodes.entry(node.clone()).or_insert_with(|| {
+            was_added = true;
+            self.graph.add_node(node.clone())
+        });
+        if was_added {
+            trace!("Added new node {idx:?} for {node}");
+        }
+        idx
     }
 
     /// Forwarding of control flow. It is sound to replace the control inputs
@@ -975,6 +901,7 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
             .iter()
             .map(|(src, edge)| {
                 let src = globalize_node(vis, src, self.tcx());
+                trace!("in control input forwarding");
                 let src_idx = self.add_node(src);
                 let new_edge = globalize_edge(vis, edge);
                 (src_idx, new_edge)
@@ -1034,6 +961,112 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
                 .map(|ann| ann.marker),
         );
         self.known_def_ids.extend(parent);
+    }
+
+    /// Check if this node is of a marked type and register that type.
+    fn handle_node_types<K: Clone>(
+        &mut self,
+        node: Node,
+        weight: &DepNode<'tcx, OneHopLocation>,
+        vis: &VisitDriver<'tcx, '_, K>,
+    ) {
+        let i = node;
+
+        trace!("Checking types for node {node:?} ({:?})", weight.place);
+
+        let Some(place_ty) =
+            self.determine_place_type(&weight.at, weight.place.as_ref(), weight.span, vis)
+        else {
+            return;
+        };
+        trace!("Has place type {:?}", place_ty);
+        // Restore after fixing https://github.com/brownsys/paralegal/issues/138
+        //let deep = !weight.is_split;
+        let deep = true;
+        let mut node_types = self.type_is_marked(place_ty, deep).collect::<HashSet<_>>();
+        for (p, _) in weight.place.iter_projections() {
+            if let Some(place_ty) = self.determine_place_type(&weight.at, p, weight.span, vis) {
+                node_types.extend(self.type_is_marked(place_ty, false));
+            }
+        }
+        self.known_def_ids.extend(node_types.iter().copied());
+        let tcx = self.tcx();
+        if !node_types.is_empty() {
+            self.types.entry(i).or_default().extend(
+                node_types
+                    .iter()
+                    .filter(|t| !tcx.is_coroutine(**t) && !tcx.def_kind(*t).is_fn_like()),
+            )
+        }
+        trace!(
+            "For node {:?} found marked node types {node_types:?}",
+            weight.place
+        );
+    }
+
+    /// Return the (sub)types of this type that are marked.
+    fn type_is_marked(
+        &'a self,
+        typ: mir::tcx::PlaceTy<'tcx>,
+        deep: bool,
+    ) -> impl Iterator<Item = TypeId> + 'a {
+        if deep {
+            Either::Left(self.marker_ctx().deep_type_markers(typ.ty).iter().copied())
+        } else {
+            Either::Right(self.marker_ctx().shallow_type_markers(typ.ty))
+        }
+        .map(|(d, _)| d)
+    }
+
+    /// Reconstruct the type for the data this node represents.
+    fn determine_place_type<K: Clone>(
+        &self,
+        at: &OneHopLocation,
+        place: mir::PlaceRef<'tcx>,
+        span: rustc_span::Span,
+        vis: &VisitDriver<'tcx, '_, K>,
+    ) -> Option<mir::tcx::PlaceTy<'tcx>> {
+        let tcx = self.tcx();
+        let function = vis.current_function();
+
+        // So actually we're going to check the base place only, because
+        // Flowistry sometimes tracks subplaces instead but we want the marker
+        // from the base place.
+        let place =
+            if self.entrypoint_is_async() && place.local.as_u32() == 1 && at.in_child.is_none() {
+                if place.projection.is_empty() {
+                    return None;
+                }
+                // in the case of targeting the top-level async closure (e.g. async args)
+                // we'll keep the first projection.
+                mir::Place {
+                    local: place.local,
+                    projection: self.tcx().mk_place_elems(&place.projection[..1]),
+                }
+            } else {
+                place.local.into()
+            };
+
+        let resolution = vis.current_function();
+
+        // Thread through each caller to recover generic arguments
+        let body = self
+            .generator
+            .pdg_constructor
+            .body_cache()
+            .get(function.def_id())
+            .body();
+        let raw_ty = place.ty(body, tcx);
+        Some(
+            try_monomorphize(
+                resolution,
+                tcx,
+                TypingEnv::fully_monomorphized(),
+                &raw_ty,
+                span,
+            )
+            .unwrap(),
+        )
     }
 
     fn node_annotations<K: Clone>(
@@ -1234,6 +1267,104 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
             self.def_id,
         )
     }
+
+    fn fix_async_args<K: Clone + std::hash::Hash + Eq>(
+        &mut self,
+        def_id: DefId,
+        generator: Instance<'tcx>,
+        loc: Location,
+        driver: &mut VisitDriver<'tcx, 'a, K>,
+    ) {
+        let tcx = self.generator.tcx();
+        let base_body = self
+            .generator
+            .pdg_constructor
+            .body_cache()
+            .try_get(def_id)
+            .unwrap_or_else(|| {
+                panic!("INVARIANT VIOLATED: body for local function {def_id:?} cannot be loaded.",)
+            })
+            .body();
+        let pgraph = driver.current_graph_as_rc();
+        let args_as_nodes = base_body
+            .args_iter()
+            .map(|arg| {
+                DepNode::new(
+                    arg.into(),
+                    OneHopLocation {
+                        location: RichLocation::Start,
+                        in_child: None,
+                    },
+                    tcx,
+                    base_body,
+                    def_id,
+                    false,
+                )
+            })
+            .collect::<Vec<_>>();
+        let return_node = DepNode::new(
+            mir::RETURN_PLACE.into(),
+            OneHopLocation {
+                location: RichLocation::End,
+                in_child: None,
+            },
+            tcx,
+            base_body,
+            def_id,
+            false,
+        );
+        for n in pgraph.iter_nodes() {
+            let generator_loc = RichLocation::Location(loc);
+            let relocated_n = |start_or_end| {
+                n.map_at(|_| OneHopLocation {
+                    location: generator_loc,
+                    in_child: Some((generator.def_id(), start_or_end)),
+                })
+            };
+
+            if n.place.local.as_u32() != 1 && n.at.location == RichLocation::Start {
+                let Some(mir::ProjectionElem::Field(id, _)) = n.place.projection.first() else {
+                    tcx.dcx().span_err(
+                        n.span,
+                        "Expected field projection on async generator in {def_id:?}",
+                    );
+                    continue;
+                };
+
+                let arg = &args_as_nodes[id.as_usize()];
+                assert!(false, "TODO remap location of n");
+                self.visit_edge(
+                    driver,
+                    arg,
+                    &relocated_n(true),
+                    &DepEdge {
+                        kind: DepEdgeKind::Data,
+                        at: OneHopLocation {
+                            location: generator_loc,
+                            in_child: None,
+                        },
+                        source_use: SourceUse::Argument(id.as_u32() as u8),
+                        target_use: TargetUse::Assign,
+                    },
+                );
+            } else if n.place.local == mir::RETURN_PLACE {
+                self.visit_edge(
+                    driver,
+                    &relocated_n(true),
+                    &return_node,
+                    &DepEdge {
+                        kind: DepEdgeKind::Data,
+                        at: OneHopLocation {
+                            location: generator_loc,
+                            in_child: None,
+                        },
+                        source_use: SourceUse::Operand,
+                        target_use: TargetUse::Return,
+                    },
+                );
+            }
+        }
+    }
 }
 
 fn globalize_node<'tcx, K: Clone>(
@@ -1284,6 +1415,7 @@ impl<'tcx, 'a, K: std::hash::Hash + Eq + Clone> Visitor<'tcx, K> for GraphAssemb
     ) {
         let idx = self.add_node(globalize_node(vis, node, self.tcx()));
         self.node_annotations(idx, node, vis);
+        self.handle_node_types(idx, node, vis);
     }
 
     fn visit_edge(
@@ -1293,6 +1425,7 @@ impl<'tcx, 'a, K: std::hash::Hash + Eq + Clone> Visitor<'tcx, K> for GraphAssemb
         dst: &DepNode<'tcx, OneHopLocation>,
         kind: &DepEdge<OneHopLocation>,
     ) {
+        trace!("In visit edge");
         let src = globalize_node(vis, src, self.tcx());
         let src_idx = self.add_node(src);
         let dst = globalize_node(vis, dst, self.tcx());
@@ -1308,6 +1441,8 @@ impl<'tcx, 'a, K: std::hash::Hash + Eq + Clone> Visitor<'tcx, K> for GraphAssemb
     ) {
         vis.visit_partial_graph(self, graph);
 
+        // TODO move to driver
+        //
         // This loop connects the control inputs that
         // are incoming to the function to those nodes in the graph who have no
         // control inputs yet.
@@ -1319,6 +1454,7 @@ impl<'tcx, 'a, K: std::hash::Hash + Eq + Clone> Visitor<'tcx, K> for GraphAssemb
         // users of the visitor.
         for node in graph.iter_nodes() {
             let new_node = globalize_node(vis, node, self.tcx());
+            trace!("In control assignment loop");
             let node = self.add_node(new_node);
 
             if !self

--- a/crates/paralegal-flow/src/ana/graph_converter.rs
+++ b/crates/paralegal-flow/src/ana/graph_converter.rs
@@ -71,7 +71,6 @@ fn assert_edge_location_invariant<'tcx, Loc: Eq + std::fmt::Display>(
 }
 
 struct GraphAssembler<'tcx, 'a> {
-    def_id: DefId,
     graph: SPDGImpl,
     // nodes: FxHashMap<DepNode<'tcx, CallString>, petgraph::graph::NodeIndex>,
     // control_inputs: Box<[(NodeIndex, DepEdge<CallString>)]>,
@@ -169,7 +168,6 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
             def_id,
         );
         Self {
-            def_id,
             graph: SPDGImpl::new(),
             nodes: Default::default(),
             control_inputs: Box::new([]),

--- a/crates/paralegal-flow/src/ana/graph_converter.rs
+++ b/crates/paralegal-flow/src/ana/graph_converter.rs
@@ -780,16 +780,23 @@ impl<'tcx, K: std::hash::Hash + Eq + Clone> Visitor<'tcx, K> for GraphAssembler<
 
     fn visit_ctrl_edge(
         &mut self,
-        vis: &mut VisitDriver<'tcx, '_, K>,
+        _vis: &mut VisitDriver<'tcx, '_, K>,
         index: usize,
         src: Node,
         dst: Node,
-        kind: &DepEdge<OneHopLocation>,
+        edge: &DepEdge<CallString>,
     ) {
         let src = self.translate_node_in(src, index);
         let dst = self.translate_node(dst);
-        let new_kind = globalize_edge(vis, kind);
-        self.graph
-            .add_edge(src.to_index(), dst.to_index(), new_kind);
+        self.graph.add_edge(
+            src.to_index(),
+            dst.to_index(),
+            EdgeInfo {
+                kind: dep_edge_kind_to_edge_kind(edge.kind),
+                at: edge.at,
+                source_use: edge.source_use,
+                target_use: edge.target_use,
+            },
+        );
     }
 }

--- a/crates/paralegal-flow/src/ana/graph_converter.rs
+++ b/crates/paralegal-flow/src/ana/graph_converter.rs
@@ -778,7 +778,7 @@ struct GraphAssembler<'tcx, 'a> {
     generator: &'a SPDGGenerator<'tcx>,
 
     /// The translation table for the function we're currently visiting.
-    nodes: Vec<GNode>,
+    nodes: Vec<Vec<GNode>>,
 }
 
 pub fn assemble_pdg<'tcx, 'a>(
@@ -879,12 +879,13 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         weight: &DepNode<'tcx, OneHopLocation>,
     ) -> GNode {
         let weight = globalize_node(vis, weight, self.tcx());
-        let prior = self.nodes[node.index()];
+        let table = self.nodes.last_mut().unwrap();
+        let prior = table[node.index()];
         if GNode(Node::end()) != prior {
             return prior;
         } else {
             let my_idx = GNode(self.graph.add_node(weight));
-            self.nodes[node.index()] = my_idx;
+            table[node.index()] = my_idx;
             my_idx
         }
     }
@@ -1387,15 +1388,15 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
     }
 
     fn translate_node(&self, node: Node) -> GNode {
-        let idx = self.nodes[node.index()];
+        let idx = self.nodes.last().unwrap()[node.index()];
         assert_ne!(idx.to_index(), Node::end(), "Node {node:?} is unknown");
         idx
     }
 
     fn with_new_translation_table<R>(&mut self, size: usize, f: impl FnOnce(&mut Self) -> R) -> R {
-        let old_table = std::mem::replace(&mut self.nodes, vec![GNode(Node::end()); size]);
+        self.nodes.push(vec![GNode(Node::end()); size]);
         let result = f(self);
-        self.nodes = old_table;
+        assert_eq!(self.nodes.pop().unwrap().len(), size);
         result
     }
 }
@@ -1449,6 +1450,17 @@ impl<'tcx, 'a, K: std::hash::Hash + Eq + Clone> Visitor<'tcx, K> for GraphAssemb
         self.with_new_ctr_inputs(vis, ctrl_inputs, |slf, vis| {
             vis.visit_inlined_call(slf, loc, inst, k)
         })
+    }
+
+    fn visit_parent_connection(
+        &mut self,
+        _vis: &mut VisitDriver<'tcx, '_, K>,
+        in_caller: Node,
+        in_this: Node,
+        _is_at_start: bool,
+    ) {
+        let [parent_table, this_table] = self.nodes.last_chunk_mut().unwrap();
+        this_table[in_this.index()] = parent_table[in_caller.index()]
     }
 
     fn visit_node(

--- a/crates/paralegal-flow/src/ana/graph_converter.rs
+++ b/crates/paralegal-flow/src/ana/graph_converter.rs
@@ -7,7 +7,7 @@ use flowistry_pdg::{rustc_portable::Location, SourceUse};
 use flowistry_pdg_construction::{
     call_tree_visit::{VisitDriver, Visitor},
     determine_async,
-    graph::{DepEdge, DepEdgeKind, DepNode, GraphConnectionPoint, OneHopLocation, PartialGraph},
+    graph::{DepEdge, DepEdgeKind, DepNode, OneHopLocation, PartialGraph},
     utils::{handle_shims, try_monomorphize, try_resolve_function, type_as_fn, ShimResult},
 };
 use paralegal_spdg::Node;
@@ -74,7 +74,6 @@ struct GraphAssembler<'tcx, 'a> {
     graph: SPDGImpl,
     // nodes: FxHashMap<DepNode<'tcx, CallString>, petgraph::graph::NodeIndex>,
     // control_inputs: Box<[(NodeIndex, DepEdge<CallString>)]>,
-    control_inputs: Box<[(GNode, EdgeInfo)]>,
     marker_assignments: HashMap<GNode, HashSet<Identifier>>,
     known_def_ids: &'a mut FxHashSet<DefId>,
     /// A map of which nodes are of which (marked) type. We build this up during
@@ -170,7 +169,6 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         Self {
             graph: SPDGImpl::new(),
             nodes: Default::default(),
-            control_inputs: Box::new([]),
             marker_assignments: Default::default(),
             known_def_ids,
             types: Default::default(),
@@ -220,45 +218,6 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
             span: src_loc_for_span(span, self.tcx()),
             local: place.local.as_u32(),
         }))
-    }
-
-    /// Forwarding of control flow. It is sound to replace the control inputs
-    /// here rather than extend them because we are guaranteed that these new
-    /// nodes are connected to the old ctrl nodes, possibly transitively.
-    ///
-    /// Each node in our graph is either connected to a local control flow
-    /// node or to the ones coming from the parent, which is established by
-    /// the `visit_partial_graph` function. By induction all nodes, including
-    /// these control flow sources are connected to the old ctrl inputs.
-    fn with_new_ctr_inputs<'c, F, R, K: Clone>(
-        &mut self,
-        vis: &mut VisitDriver<'tcx, 'c, K>,
-        new_ctrl_inputs: &[GraphConnectionPoint<'tcx>],
-        f: F,
-    ) -> R
-    where
-        F: FnOnce(&mut Self, &mut VisitDriver<'tcx, 'c, K>) -> R,
-    {
-        let new_ctrl_inputs: Box<[(GNode, EdgeInfo)]> = new_ctrl_inputs
-            .iter()
-            .map(|(node, edge)| {
-                let src_idx = self.translate_node(*node);
-                let new_edge = globalize_edge(vis, edge);
-                (src_idx, new_edge)
-            })
-            .collect();
-        // The last thing we need to ensure for that to hold is that the new
-        // ctrl inputs must not be empty. So if they are we leave the old one's intact.
-        let old_ctrl_inputs = if new_ctrl_inputs.is_empty() {
-            Box::new([])
-        } else {
-            std::mem::replace(&mut self.control_inputs, new_ctrl_inputs)
-        };
-        let r = f(self, vis);
-        if !old_ctrl_inputs.is_empty() {
-            self.control_inputs = old_ctrl_inputs;
-        }
-        r
     }
 
     fn ctx(&self) -> &Pctx<'tcx> {
@@ -707,7 +666,11 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
     }
 
     fn translate_node(&self, node: Node) -> GNode {
-        let idx = self.nodes.last().unwrap()[node.index()];
+        self.translate_node_in(node, self.nodes.len() - 1)
+    }
+
+    fn translate_node_in(&self, node: Node, index: usize) -> GNode {
+        let idx = self.nodes[index][node.index()];
         assert_ne!(idx.to_index(), Node::end(), "Node {node:?} is unknown");
         idx
     }
@@ -762,19 +725,6 @@ impl GNode {
 }
 
 impl<'tcx, K: std::hash::Hash + Eq + Clone> Visitor<'tcx, K> for GraphAssembler<'tcx, '_> {
-    fn visit_inlined_call(
-        &mut self,
-        vis: &mut VisitDriver<'tcx, '_, K>,
-        loc: Location,
-        inst: Instance<'tcx>,
-        k: &K,
-        ctrl_inputs: &[GraphConnectionPoint<'tcx>],
-    ) {
-        self.with_new_ctr_inputs(vis, ctrl_inputs, |slf, vis| {
-            vis.visit_inlined_call(slf, loc, inst, k)
-        })
-    }
-
     fn visit_parent_connection(
         &mut self,
         _vis: &mut VisitDriver<'tcx, '_, K>,
@@ -825,31 +775,21 @@ impl<'tcx, K: std::hash::Hash + Eq + Clone> Visitor<'tcx, K> for GraphAssembler<
                 slf.tcx().def_path_str(graph.def_id())
             );
             vis.visit_partial_graph(slf, graph);
-
-            // TODO move to driver
-            //
-            // This loop connects the control inputs that
-            // are incoming to the function to those nodes in the graph who have no
-            // control inputs yet.
-            //
-            // We do this here instead of in "visit_node", because that gets called
-            // before the "visit_edge" function, meaning we can't yet see the
-            // potential control inputs of the node. We could have the visitor use
-            // an opposite ordering, but that is counterintuitive to other potential
-            // users of the visitor.
-            for (node, _) in graph.iter_nodes() {
-                if !graph
-                    .raw()
-                    .edges_directed(node, petgraph::Direction::Incoming)
-                    .any(|e| e.weight().is_control())
-                {
-                    let local_node = slf.translate_node(node);
-                    for (src, edge) in slf.control_inputs.iter() {
-                        slf.graph
-                            .add_edge(src.to_index(), local_node.to_index(), edge.clone());
-                    }
-                }
-            }
         })
+    }
+
+    fn visit_ctrl_edge(
+        &mut self,
+        vis: &mut VisitDriver<'tcx, '_, K>,
+        index: usize,
+        src: Node,
+        dst: Node,
+        kind: &DepEdge<OneHopLocation>,
+    ) {
+        let src = self.translate_node_in(src, index);
+        let dst = self.translate_node(dst);
+        let new_kind = globalize_edge(vis, kind);
+        self.graph
+            .add_edge(src.to_index(), dst.to_index(), new_kind);
     }
 }

--- a/crates/paralegal-flow/src/ana/graph_converter.rs
+++ b/crates/paralegal-flow/src/ana/graph_converter.rs
@@ -1294,7 +1294,7 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
     fn fix_async_args<K: Clone + std::hash::Hash + Eq>(
         &mut self,
         def_id: DefId,
-        generator: Instance<'tcx>,
+        _generator: Instance<'tcx>,
         loc: Location,
         driver: &mut VisitDriver<'tcx, 'a, K>,
     ) {
@@ -1324,9 +1324,12 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
             driver.globalize_location(&RichLocation::End.into()),
             base_body.local_decls[mir::RETURN_PLACE].source_info.span,
         );
+        let generator_loc = RichLocation::Location(loc);
+        let transition_at = CallString::new(&[GlobalLocation {
+            location: generator_loc,
+            function: def_id,
+        }]);
         for (nidx, n) in pgraph.iter_nodes() {
-            let generator_loc = RichLocation::Location(loc);
-
             if n.place.local.as_u32() == 1 && n.at.location == RichLocation::Start {
                 let ridx = self.translate_node(nidx);
                 let Some(mir::ProjectionElem::Field(id, _)) = n.place.projection.first() else {
@@ -1341,36 +1344,24 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
                 self.graph.add_edge(
                     arg.to_index(),
                     ridx.to_index(),
-                    globalize_edge(
-                        driver,
-                        &DepEdge {
-                            kind: DepEdgeKind::Data,
-                            at: OneHopLocation {
-                                location: generator_loc,
-                                in_child: None,
-                            },
-                            source_use: SourceUse::Argument(id.as_u32() as u8),
-                            target_use: TargetUse::Assign,
-                        },
-                    ),
+                    EdgeInfo {
+                        kind: EdgeKind::Data,
+                        at: transition_at,
+                        source_use: SourceUse::Argument(id.as_u32() as u8),
+                        target_use: TargetUse::Assign,
+                    },
                 );
             } else if n.place.local == mir::RETURN_PLACE {
                 let ridx = self.translate_node(nidx);
                 self.graph.add_edge(
                     ridx.to_index(),
                     return_node.to_index(),
-                    globalize_edge(
-                        driver,
-                        &DepEdge {
-                            kind: DepEdgeKind::Data,
-                            at: OneHopLocation {
-                                location: generator_loc,
-                                in_child: None,
-                            },
-                            source_use: SourceUse::Operand,
-                            target_use: TargetUse::Return,
-                        },
-                    ),
+                    EdgeInfo {
+                        kind: EdgeKind::Data,
+                        at: transition_at,
+                        source_use: SourceUse::Operand,
+                        target_use: TargetUse::Return,
+                    },
                 );
             }
         }

--- a/crates/paralegal-flow/src/ana/graph_converter.rs
+++ b/crates/paralegal-flow/src/ana/graph_converter.rs
@@ -31,7 +31,7 @@ use either::Either;
 use flowistry::mir::FlowistryInput;
 use petgraph::{
     visit::{IntoNodeReferences, NodeIndexable, NodeRef},
-    Direction,
+    Direction::{self, Outgoing},
 };
 
 /// Structure responsible for converting one [`DepGraph`] into an [`SPDG`].
@@ -769,7 +769,6 @@ struct GraphAssembler<'tcx, 'a> {
     graph: SPDGImpl,
     // nodes: FxHashMap<DepNode<'tcx, CallString>, petgraph::graph::NodeIndex>,
     // control_inputs: Box<[(NodeIndex, DepEdge<CallString>)]>,
-    nodes: FxHashMap<(Node, CallString), GNode>,
     control_inputs: Box<[(GNode, EdgeInfo)]>,
     marker_assignments: HashMap<GNode, HashSet<Identifier>>,
     known_def_ids: &'a mut FxHashSet<DefId>,
@@ -777,6 +776,9 @@ struct GraphAssembler<'tcx, 'a> {
     /// conversion.
     types: HashMap<GNode, Vec<DefId>>,
     generator: &'a SPDGGenerator<'tcx>,
+
+    /// The translation table for the function we're currently visiting.
+    nodes: Vec<GNode>,
 }
 
 pub fn assemble_pdg<'tcx, 'a>(
@@ -877,10 +879,14 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         weight: &DepNode<'tcx, OneHopLocation>,
     ) -> GNode {
         let weight = globalize_node(vis, weight, self.tcx());
-        let cs = weight.at;
-        let my_idx = GNode(self.graph.add_node(weight));
-        self.nodes.insert((node, cs), my_idx);
-        my_idx
+        let prior = self.nodes[node.index()];
+        if GNode(Node::end()) != prior {
+            return prior;
+        } else {
+            let my_idx = GNode(self.graph.add_node(weight));
+            self.nodes[node.index()] = my_idx;
+            my_idx
+        }
     }
 
     fn add_untranslatable_node(
@@ -918,8 +924,7 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         let new_ctrl_inputs: Box<[(GNode, EdgeInfo)]> = new_ctrl_inputs
             .iter()
             .map(|(node, edge)| {
-                let cs = vis.globalize_location(&g.node_props(*node).at);
-                let src_idx = self.translate_node(*node, cs).unwrap();
+                let src_idx = self.translate_node(*node);
                 let new_edge = globalize_edge(vis, edge);
                 (src_idx, new_edge)
             })
@@ -1086,6 +1091,7 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
 
     fn node_annotations<K: Clone>(
         &mut self,
+        local_node: Node,
         node: GNode,
         weight: &DepNode<'tcx, OneHopLocation>,
         vis: &VisitDriver<'tcx, '_, K>,
@@ -1097,7 +1103,6 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         let leaf_loc = weight.at.location;
         let function = vis.current_function();
         let function_id = function.def_id();
-        let cs = self.graph.node_weight(node.to_index()).unwrap().at;
 
         let body = self
             .generator
@@ -1187,19 +1192,18 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
                 let mut is_return_use = false;
                 let mut has_no_data_edges = true;
 
-                for (from, to, edge_weight) in graph.iter_edges() {
-                    let from = self.translate_node(from, cs).unwrap();
-                    let to = self.translate_node(to, cs).unwrap();
-                    if from == node {
-                        let SourceUse::Argument(arg) = edge_weight.source_use else {
-                            continue;
-                        };
-                        self.register_annotations_for_function(node, f, |ann| {
-                            ann.refinement.on_argument().contains(arg as u32).unwrap()
-                        });
-                    } else if to == node && edge_weight.kind == DepEdgeKind::Data {
+                for eref in graph.raw().edges_directed(local_node, petgraph::Outgoing) {
+                    let SourceUse::Argument(arg) = eref.weight().source_use else {
+                        continue;
+                    };
+                    self.register_annotations_for_function(node, f, |ann| {
+                        ann.refinement.on_argument().contains(arg as u32).unwrap()
+                    });
+                }
+                for eref in graph.raw().edges_directed(local_node, petgraph::Incoming) {
+                    if eref.weight().kind == DepEdgeKind::Data {
                         has_no_data_edges = false;
-                        let at = edge_weight.at.clone();
+                        let at = eref.weight().at.clone();
                         #[cfg(debug_assertions)]
                         assert_edge_location_invariant(
                             self.tcx(),
@@ -1211,7 +1215,7 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
                                 location: at.location,
                             },
                         );
-                        if weight.at == at && edge_weight.target_use.is_return() {
+                        if weight.at == at && eref.weight().target_use.is_return() {
                             is_return_use = true;
                         }
                     }
@@ -1382,8 +1386,17 @@ impl<'tcx, 'a> GraphAssembler<'tcx, 'a> {
         }
     }
 
-    fn translate_node(&self, node: Node, cs: CallString) -> Option<GNode> {
-        self.nodes.get(&(node, cs)).cloned()
+    fn translate_node(&self, node: Node) -> GNode {
+        let idx = self.nodes[node.index()];
+        assert_ne!(idx.to_index(), Node::end(), "Node {node:?} is unknown");
+        idx
+    }
+
+    fn with_new_translation_table<R>(&mut self, size: usize, f: impl FnOnce(&mut Self) -> R) -> R {
+        let old_table = std::mem::replace(&mut self.nodes, vec![GNode(Node::end()); size]);
+        let result = f(self);
+        self.nodes = old_table;
+        result
     }
 }
 
@@ -1445,7 +1458,7 @@ impl<'tcx, 'a, K: std::hash::Hash + Eq + Clone> Visitor<'tcx, K> for GraphAssemb
         node: &DepNode<'tcx, OneHopLocation>,
     ) {
         let idx = self.add_node(k, vis, node);
-        self.node_annotations(idx, node, vis);
+        self.node_annotations(k, idx, node, vis);
         self.handle_node_types(idx, node, vis);
     }
 
@@ -1456,9 +1469,8 @@ impl<'tcx, 'a, K: std::hash::Hash + Eq + Clone> Visitor<'tcx, K> for GraphAssemb
         dst: Node,
         kind: &DepEdge<OneHopLocation>,
     ) {
-        let at = vis.globalize_location(&kind.at);
-        let src = self.translate_node(src, at).unwrap();
-        let dst = self.translate_node(dst, at).unwrap();
+        let src = self.translate_node(src);
+        let dst = self.translate_node(dst);
         let new_kind = globalize_edge(vis, kind);
         self.graph
             .add_edge(src.to_index(), dst.to_index(), new_kind);
@@ -1469,32 +1481,33 @@ impl<'tcx, 'a, K: std::hash::Hash + Eq + Clone> Visitor<'tcx, K> for GraphAssemb
         vis: &mut VisitDriver<'tcx, '_, K>,
         graph: &PartialGraph<'tcx, K>,
     ) {
-        vis.visit_partial_graph(self, graph);
+        self.with_new_translation_table(graph.node_count(), |slf: &mut Self| {
+            vis.visit_partial_graph(slf, graph);
 
-        // TODO move to driver
-        //
-        // This loop connects the control inputs that
-        // are incoming to the function to those nodes in the graph who have no
-        // control inputs yet.
-        //
-        // We do this here instead of in "visit_node", because that gets called
-        // before the "visit_edge" function, meaning we can't yet see the
-        // potential control inputs of the node. We could have the visitor use
-        // an opposite ordering, but that is counterintuitive to other potential
-        // users of the visitor.
-        for (node, node_weight) in graph.iter_nodes() {
-            if !graph
-                .raw()
-                .edges_directed(node, petgraph::Direction::Incoming)
-                .any(|e| e.weight().is_control())
-            {
-                let at = vis.globalize_location(&node_weight.at);
-                let local_node = self.translate_node(node, at).unwrap();
-                for (src, edge) in self.control_inputs.iter() {
-                    self.graph
-                        .add_edge(src.to_index(), local_node.to_index(), edge.clone());
+            // TODO move to driver
+            //
+            // This loop connects the control inputs that
+            // are incoming to the function to those nodes in the graph who have no
+            // control inputs yet.
+            //
+            // We do this here instead of in "visit_node", because that gets called
+            // before the "visit_edge" function, meaning we can't yet see the
+            // potential control inputs of the node. We could have the visitor use
+            // an opposite ordering, but that is counterintuitive to other potential
+            // users of the visitor.
+            for (node, _) in graph.iter_nodes() {
+                if !graph
+                    .raw()
+                    .edges_directed(node, petgraph::Direction::Incoming)
+                    .any(|e| e.weight().is_control())
+                {
+                    let local_node = slf.translate_node(node);
+                    for (src, edge) in slf.control_inputs.iter() {
+                        slf.graph
+                            .add_edge(src.to_index(), local_node.to_index(), edge.clone());
+                    }
                 }
             }
-        }
+        })
     }
 }

--- a/crates/paralegal-flow/src/ana/mod.rs
+++ b/crates/paralegal-flow/src/ana/mod.rs
@@ -28,7 +28,6 @@ use flowistry_pdg_construction::{
 };
 use inline_judge::{InlineJudgement, K};
 use itertools::Itertools;
-use petgraph::visit::GraphBase;
 
 use rustc_hash::FxHashSet;
 use rustc_hir::{
@@ -44,7 +43,6 @@ use rustc_span::{ErrorGuaranteed, FileNameDisplayPreference, Span as RustSpan, S
 mod graph_converter;
 mod inline_judge;
 
-use graph_converter::GraphConverter;
 use std::time::Duration;
 
 pub use self::inline_judge::InlineJudge;
@@ -457,10 +455,6 @@ fn src_loc_for_span(span: RustSpan, tcx: TyCtxt) -> Span {
             col: end_col as u32,
         },
     }
-}
-
-fn default_index() -> <SPDGImpl as GraphBase>::NodeId {
-    <SPDGImpl as GraphBase>::NodeId::end()
 }
 
 /// Checks the invariant that [`SPDGGenerator::collect_type_info`] should

--- a/crates/paralegal-flow/src/lib.rs
+++ b/crates/paralegal-flow/src/lib.rs
@@ -52,14 +52,14 @@ use desc::utils::write_sep;
 
 use flowistry_pdg_construction::body_cache::{dump_mir_and_borrowck_facts, intermediate_out_dir};
 use log::Level;
-use paralegal_spdg::{AnalyzerStats, ProgramDescription, STAT_FILE_EXT};
+use paralegal_spdg::{AnalyzerStats, DisplayPath, ProgramDescription, STAT_FILE_EXT};
 use rustc_middle::ty::TyCtxt;
 use rustc_plugin::CrateFilter;
 use rustc_span::ErrorGuaranteed;
 
 pub use std::collections::{HashMap, HashSet};
 use std::{
-    fmt::Display,
+    fmt::{write, Display},
     fs::File,
     io::BufWriter,
     path::PathBuf,
@@ -316,8 +316,27 @@ impl Callbacks {
         tcx.dcx().abort_if_errors();
 
         if self.opts.dbg().dump_spdg() {
-            let out = std::fs::File::create("call-only-flow.gv")?;
-            paralegal_spdg::dot::dump(&desc, out)?;
+            let td = std::env::var("CARGO_MANIFEST_DIR").unwrap_or(".".to_string());
+            let mut pb = std::path::PathBuf::from(&td);
+            pb.push("target");
+            if !pb.exists() {
+                error!(
+                    "Target directory {} should exist, will create one.",
+                    pb.display()
+                );
+            }
+            pb.push("paralegal-dump");
+            pb.push("graph");
+            std::fs::create_dir_all(&pb).unwrap();
+            paralegal_spdg::dot::dump_all_separate(&desc, |name| {
+                let mut pb = pb.clone();
+                pb.push(format!(
+                    "{}",
+                    Print(|f| write_sep(f, "-", name.iter(), Display::fmt))
+                ));
+                pb.set_extension("graph.gv");
+                pb
+            })?;
         }
 
         generator

--- a/crates/paralegal-flow/src/lib.rs
+++ b/crates/paralegal-flow/src/lib.rs
@@ -52,14 +52,14 @@ use desc::utils::write_sep;
 
 use flowistry_pdg_construction::body_cache::{dump_mir_and_borrowck_facts, intermediate_out_dir};
 use log::Level;
-use paralegal_spdg::{AnalyzerStats, DisplayPath, ProgramDescription, STAT_FILE_EXT};
+use paralegal_spdg::{AnalyzerStats, ProgramDescription, STAT_FILE_EXT};
 use rustc_middle::ty::TyCtxt;
 use rustc_plugin::CrateFilter;
 use rustc_span::ErrorGuaranteed;
 
 pub use std::collections::{HashMap, HashSet};
 use std::{
-    fmt::{write, Display},
+    fmt::Display,
     fs::File,
     io::BufWriter,
     path::PathBuf,

--- a/crates/paralegal-flow/src/test_utils.rs
+++ b/crates/paralegal-flow/src/test_utils.rs
@@ -23,8 +23,8 @@ use std::{
 
 use paralegal_spdg::{
     traverse::{generic_flows_to, generic_influencers, EdgeSelection},
-    utils::write_sep,
-    DefInfo, EdgeInfo, Endpoint, Node, TypeId, SPDG,
+    utils::{display_list, write_sep, DisplayList},
+    DefInfo, DisplayPath, EdgeInfo, Endpoint, Node, TypeId, SPDG,
 };
 
 use flowistry_pdg::CallString;
@@ -495,7 +495,7 @@ impl<'g> CtrlRef<'g> {
             cs.len() == 1,
             "expected only one call site for {}, found {}",
             fun.info_for(fun.ident).name,
-            cs.len()
+            display_list(cs.iter().map(|c| c.call_site))
         );
         cs.pop().unwrap()
     }
@@ -540,6 +540,15 @@ impl<'g> FnRef<'g> {
 pub struct CallStringRef<'g> {
     call_site: CallString,
     ctrl: &'g CtrlRef<'g>,
+}
+
+impl std::fmt::Debug for CallStringRef<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CallStringRef")
+            .field("call_site", &self.call_site)
+            .field("ctrl", &DisplayPath::from(&self.ctrl.ctrl.path))
+            .finish()
+    }
 }
 
 impl Hash for CallStringRef<'_> {

--- a/crates/paralegal-flow/src/test_utils.rs
+++ b/crates/paralegal-flow/src/test_utils.rs
@@ -191,6 +191,13 @@ pub struct InlineTestBuilder {
     extra_args: Vec<String>,
 }
 
+#[macro_export]
+macro_rules! inline_test {
+    ($($t:tt)*) => {
+        InlineTestBuilder::new(stringify!($($t)*))
+    };
+}
+
 impl InlineTestBuilder {
     /// Constructor.
     ///
@@ -447,6 +454,11 @@ impl<'g> CtrlRef<'g> {
 
     pub fn marked(&self, marker: impl Into<Identifier>) -> NodeRefs<'_> {
         let marker = marker.into();
+        let marked_types = self
+            .graph
+            .marked_types(marker)
+            .into_iter()
+            .collect::<HashSet<_>>();
         NodeRefs {
             nodes: self
                 .ctrl
@@ -454,6 +466,13 @@ impl<'g> CtrlRef<'g> {
                 .iter()
                 .filter(|(_, markers)| markers.contains(&marker))
                 .map(|(n, _)| *n)
+                .chain(self.ctrl.type_assigns.iter().filter_map(|(n, types)| {
+                    types
+                        .0
+                        .iter()
+                        .any(|t| marked_types.contains(t))
+                        .then_some(*n)
+                }))
                 .collect(),
             graph: self,
         }
@@ -516,6 +535,13 @@ impl<'g> CtrlRef<'g> {
                 .iter()
                 .filter_map(|(n, types)| types.0.contains(&typ).then_some(*n))
                 .collect(),
+        }
+    }
+
+    pub fn arguments(&'g self) -> NodeRefs<'g> {
+        NodeRefs {
+            nodes: self.ctrl.arguments.to_vec(),
+            graph: self,
         }
     }
 }
@@ -667,6 +693,18 @@ impl<'g> NodeRefs<'g> {
 pub struct NodeRef<'g> {
     node: Node,
     graph: &'g CtrlRef<'g>,
+}
+
+impl Debug for NodeRef<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let weight = self.graph.ctrl.graph.node_weight(self.node).unwrap();
+        f.debug_struct("NodeRef")
+            .field("node", &self.node)
+            .field("description", &weight.description)
+            .field("at", &weight.at)
+            .field("graph", &DisplayPath::from(&self.graph.ctrl.path))
+            .finish()
+    }
 }
 
 impl<'g> HasGraph<'g> for &NodeRef<'g> {

--- a/crates/paralegal-flow/src/test_utils.rs
+++ b/crates/paralegal-flow/src/test_utils.rs
@@ -23,7 +23,7 @@ use std::{
 
 use paralegal_spdg::{
     traverse::{generic_flows_to, generic_influencers, EdgeSelection},
-    utils::{display_list, write_sep, DisplayList},
+    utils::{display_list, write_sep},
     DefInfo, DisplayPath, EdgeInfo, Endpoint, Node, TypeId, SPDG,
 };
 

--- a/crates/paralegal-flow/src/utils/mod.rs
+++ b/crates/paralegal-flow/src/utils/mod.rs
@@ -1,8 +1,9 @@
 //! Utility functions, general purpose structs and extension traits
 
 extern crate smallvec;
+use flowistry::mir::FlowistryInput;
 use flowistry_pdg::RichLocation;
-use flowistry_pdg_construction::utils::type_as_fn;
+use flowistry_pdg_construction::{body_cache::BodyCache, is_async_trait_fn, utils::type_as_fn};
 use thiserror::Error;
 
 use crate::{desc::Identifier, rustc_span::ErrorGuaranteed, Either, Symbol, TyCtxt};
@@ -81,6 +82,33 @@ pub fn body_span<'tcx>(tcx: TyCtxt<'tcx>, body: &mir::Body<'tcx>) -> RustSpan {
         })
         .reduce(RustSpan::to)
         .unwrap_or(body_span)
+}
+
+/// If `did` is a method of an `impl` of a trait, then return the `DefId` that
+/// refers to the method on the trait definition.
+pub fn get_parent(tcx: TyCtxt, did: DefId) -> Option<DefId> {
+    let ident = tcx.opt_item_ident(did)?;
+    let kind = match tcx.def_kind(did) {
+        kind if kind.is_fn_like() => ty::AssocKind::Fn,
+        // todo allow constants and types also
+        _ => return None,
+    };
+    let r#impl = tcx.impl_of_method(did)?;
+    let r#trait = tcx.trait_id_of_impl(r#impl)?;
+    let id = tcx
+        .associated_items(r#trait)
+        .find_by_name_and_kind(tcx, ident, kind, r#trait)?
+        .def_id;
+    Some(id)
+}
+
+pub fn entrypoint_is_async<'tcx>(
+    body_cache: &BodyCache<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    def_id: DefId,
+) -> bool {
+    tcx.asyncness(def_id).is_async()
+        || is_async_trait_fn(tcx, def_id, body_cache.get(def_id).body())
 }
 
 /// This is meant as an extension trait for `ast::Attribute`. The main method of

--- a/crates/paralegal-flow/src/utils/print.rs
+++ b/crates/paralegal-flow/src/utils/print.rs
@@ -1,13 +1,7 @@
 pub use paralegal_spdg::utils::write_sep;
 use std::fmt::{Debug, Display, Formatter, Result};
 
-pub struct Print<F: Fn(&mut Formatter<'_>) -> Result>(pub F);
-
-impl<F: Fn(&mut Formatter<'_>) -> Result> Display for Print<F> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        (self.0)(f)
-    }
-}
+pub use flowistry_pdg_construction::utils::Print;
 
 #[derive(Hash, Eq, Ord, PartialEq, PartialOrd, Clone, Copy)]
 pub struct DisplayViaDebug<T>(pub T);

--- a/crates/paralegal-flow/tests/async_tests.rs
+++ b/crates/paralegal-flow/tests/async_tests.rs
@@ -3,6 +3,7 @@
 extern crate lazy_static;
 
 use flowistry_pdg::CallString;
+use paralegal_flow::inline_test;
 use paralegal_flow::test_utils::*;
 use paralegal_spdg::Identifier;
 
@@ -648,4 +649,76 @@ fn explicit_call_to_poll() {
         "mir".to_string(),
     ])
     .check_ctrl(|_| ());
+}
+
+#[test]
+fn async_arg_markers() {
+    inline_test! {
+        #[paralegal_flow::marker(source, arguments = [0])]
+        #[paralegal_flow::marker(no_source, arguments = [1])]
+        #[paralegal_flow::marker(source_2, arguments = [2])]
+        #[paralegal_flow::marker(sink, return)]
+        async fn main(src: usize, other: usize, last: usize) -> usize {
+            let some = src + other;
+            src + 9 + last
+        }
+    }
+    .check_ctrl(|ctrl| {
+        // check direct
+        let args = ctrl.arguments().as_singles().collect::<Vec<_>>();
+        let [src, other, last] = args.as_slice() else {
+            panic!("Expected exactly two arguments, got {:?}", args);
+        };
+        let returns = ctrl.return_value().as_singles().collect::<Vec<_>>();
+        let [snk] = returns.as_slice() else {
+            panic!("Expected exactly one return value, got {:?}", returns);
+        };
+
+        assert!(src.flows_to_data(snk));
+        assert!(!other.flows_to_data(snk));
+        assert!(last.flows_to_data(snk));
+
+        // Check via markers
+        let sources = ctrl.marked(Identifier::new_intern("source"));
+        let source_2 = ctrl.marked(Identifier::new_intern("source_2"));
+        let no_source = ctrl.marked(Identifier::new_intern("no_source"));
+        let sinks = ctrl.marked(Identifier::new_intern("sink"));
+        assert!(!sources.is_empty());
+        assert!(!source_2.is_empty());
+        assert!(!no_source.is_empty());
+        assert!(!sinks.is_empty());
+        assert!(sources.flows_to_any(&sinks));
+        assert!(source_2.flows_to_any(&sinks));
+        assert!(!no_source.flows_to_any(&sinks));
+    })
+}
+
+// TODO marked type as argument test
+#[test]
+fn async_arg_marked_via_type() {
+    inline_test! {
+        #[paralegal_flow::marker(source)]
+        struct T1(u32);
+
+        #[paralegal_flow::marker(source_2)]
+        struct T2(u32);
+
+        #[paralegal_flow::marker(sink)]
+        struct T3(u32);
+
+        async fn main(src: T1, other: T2) -> T3 {
+            let some = src.0 + other.0;
+            T3(src.0 + 9)
+        }
+    }
+    .check_ctrl(|ctrl| {
+        let sources = ctrl.marked(Identifier::new_intern("source"));
+        let source_2 = ctrl.marked(Identifier::new_intern("source_2"));
+        let sinks = ctrl.marked(Identifier::new_intern("sink"));
+        assert!(!sources.is_empty());
+        assert!(!source_2.is_empty());
+        assert!(!sinks.is_empty());
+        assert!(sources.flows_to_any(&sinks));
+        assert!(!source_2.flows_to_any(&sinks));
+    })
 }

--- a/crates/paralegal-flow/tests/async_tests.rs
+++ b/crates/paralegal-flow/tests/async_tests.rs
@@ -722,3 +722,42 @@ fn async_arg_marked_via_type() {
         assert!(!source_2.flows_to_any(&sinks));
     })
 }
+
+#[test]
+fn async_args_and_local_variable() {
+    inline_test! {
+        #[paralegal_flow::marker(noinline, return)]
+        async fn i_force_await() {
+
+        }
+
+        fn compute() -> usize {
+            42
+        }
+
+        #[paralegal_flow::marker(source, arguments = [0])]
+        #[paralegal_flow::marker(no_source, arguments = [1])]
+        #[paralegal_flow::marker(source_2, arguments = [2])]
+        #[paralegal_flow::marker(sink, return)]
+        async fn main(src: usize, other: usize, last: usize) -> usize {
+            let some = src + other;
+            let intermediate = last + compute();
+            i_force_await().await;
+            src + intermediate
+        }
+    }
+    .check_ctrl(|ctrl| {
+        // Check via markers
+        let sources = ctrl.marked(Identifier::new_intern("source"));
+        let source_2 = ctrl.marked(Identifier::new_intern("source_2"));
+        let no_source = ctrl.marked(Identifier::new_intern("no_source"));
+        let sinks = ctrl.marked(Identifier::new_intern("sink"));
+        assert!(!sources.is_empty());
+        assert!(!source_2.is_empty());
+        assert!(!no_source.is_empty());
+        assert!(!sinks.is_empty());
+        assert!(sources.flows_to_any(&sinks));
+        assert!(source_2.flows_to_any(&sinks));
+        assert!(!no_source.flows_to_any(&sinks));
+    })
+}

--- a/crates/paralegal-flow/tests/async_tests.rs
+++ b/crates/paralegal-flow/tests/async_tests.rs
@@ -565,8 +565,8 @@ fn field_precision_at_future_consumption() {
 
 fn control_flow_overtaint_check(ctrl: CtrlRef<'_>) {
     let checks = ctrl.marked(Identifier::new_intern("is_check"));
-    let sensitive_1 = ctrl.marked(Identifier::new_intern("is_sensitive1"));
-    let sensitive_2 = ctrl.marked(Identifier::new_intern("is_sensitive2"));
+    let sensitive_1 = dbg!(ctrl.marked(Identifier::new_intern("is_sensitive1")));
+    let sensitive_2 = dbg!(ctrl.marked(Identifier::new_intern("is_sensitive2")));
 
     assert!(!checks.is_empty());
     assert!(!sensitive_1.is_empty());

--- a/crates/paralegal-flow/tests/async_tests.rs
+++ b/crates/paralegal-flow/tests/async_tests.rs
@@ -2,6 +2,7 @@
 #[macro_use]
 extern crate lazy_static;
 
+use flowistry_pdg::CallString;
 use paralegal_flow::test_utils::*;
 use paralegal_spdg::Identifier;
 
@@ -242,6 +243,24 @@ define_test!(no_overtaint_over_poll
 
 define_test!(return_from_async: graph -> {
     let input_fn = graph.function("some_input");
+    let instruction_info = &graph.graph().desc.instruction_info;
+    println!("Looking for function {:?}", input_fn.ident);
+    let filter = |m: CallString| {
+        instruction_info[&m.leaf()]
+            .kind
+            .as_function_call()
+            .is_some_and(|i| i.id == input_fn.ident)
+    };
+    for e in graph.spdg().graph
+            .edge_weights()
+            .filter(|e| filter(e.at)) {
+                println!("Edge {e} is at function in question");
+            }
+    for n in graph.spdg()
+            .graph.node_weights()
+            .filter(|n| filter(n.at)) {
+                println!("Node {n} is at function in question");
+            }
     let input = graph.call_site(&input_fn);
 
     assert!(graph.returns(&input.output()))

--- a/crates/paralegal-flow/tests/control_flow_tests.rs
+++ b/crates/paralegal-flow/tests/control_flow_tests.rs
@@ -2,7 +2,7 @@
 #[macro_use]
 extern crate lazy_static;
 
-use paralegal_flow::test_utils::*;
+use paralegal_flow::{inline_test, test_utils::*};
 
 const CRATE_DIR: &str = "tests/control-flow-tests";
 
@@ -166,3 +166,74 @@ define_test!(process_no_args : graph -> {
     assert!(getx.output().flows_to_any(&send.input()));
     assert!(getx.output().influences_next_control(&get.output()));
 });
+
+#[test]
+fn cross_function_control_flow() {
+    inline_test! {
+        fn main() -> Result<(), ()> {
+            has_influence()?;
+            wrapper();
+            Ok(())
+        }
+
+        fn wrapper() {
+            influenced();
+        }
+
+        #[paralegal_flow::marker(has_influence, return)]
+        fn has_influence() -> Result<(), ()> {
+            Ok(())
+        }
+
+        #[paralegal_flow::marker(influenced, return)]
+        fn influenced() {}
+    }
+    .check_ctrl(|ctrl| {
+        let has_influence = ctrl.marked("has_influence");
+        let influenced = ctrl.marked("influenced");
+
+        dbg!(&ctrl.spdg().markers);
+
+        assert!(!has_influence.is_empty());
+        assert!(!influenced.is_empty());
+
+        assert!(has_influence.influences_ctrl(&influenced));
+    });
+}
+
+#[test]
+fn cross_function_control_flow_with_skip() {
+    inline_test! {
+        fn main() -> Result<(), ()> {
+            has_influence()?;
+            wrapper();
+            Ok(())
+        }
+
+        fn wrapper() {
+            skip();
+        }
+
+        fn skip() {
+            influenced();
+        }
+
+        #[paralegal_flow::marker(has_influence, return)]
+        fn has_influence() -> Result<(), ()> {
+            Ok(())
+        }
+
+        #[paralegal_flow::marker(influenced, return)]
+        fn influenced() {
+        }
+    }
+    .check_ctrl(|ctrl| {
+        let has_influence = ctrl.marked("has_influence");
+        let influenced = ctrl.marked("influenced");
+
+        assert!(!has_influence.is_empty());
+        assert!(!influenced.is_empty());
+
+        assert!(has_influence.influences_ctrl(&influenced));
+    });
+}

--- a/crates/paralegal-flow/tests/control_flow_tests.rs
+++ b/crates/paralegal-flow/tests/control_flow_tests.rs
@@ -202,7 +202,7 @@ fn cross_function_control_flow() {
 }
 
 #[test]
-fn cross_function_control_flow_with_skip() {
+fn cross_function_control_flow_with_skip_simple() {
     inline_test! {
         fn main() -> Result<(), ()> {
             has_influence()?;
@@ -235,5 +235,60 @@ fn cross_function_control_flow_with_skip() {
         assert!(!influenced.is_empty());
 
         assert!(has_influence.influences_ctrl(&influenced));
+    });
+}
+
+#[test]
+fn cross_function_control_flow_with_skip_complex() {
+    inline_test! {
+        fn main() -> Result<(), ()> {
+            let mut result = 0;
+            let status = has_influence()?;
+            result += 1;
+            let mut values = vec![1, 2, 3];
+            for v in &mut values {
+                *v += result;
+            }
+            if values.iter().sum::<i32>() > no_influence() {
+            } else {
+                result -= 1;
+            }
+            wrapper();
+            let _final_check = result * values.len() as i32;
+            Ok(())
+        }
+
+        fn wrapper() {
+            skip();
+        }
+
+        fn skip() {
+            influenced();
+        }
+
+        #[paralegal_flow::marker(has_influence, return)]
+        fn has_influence() -> Result<(), ()> {
+            Ok(())
+        }
+        #[paralegal_flow::marker(no_influence, return)]
+        fn no_influence() -> i32 {
+            0
+        }
+
+        #[paralegal_flow::marker(influenced, return)]
+        fn influenced() {
+        }
+    }
+    .check_ctrl(|ctrl| {
+        let has_influence = ctrl.marked("has_influence");
+        let influenced = ctrl.marked("influenced");
+        let no_influence = ctrl.marked("no_influence");
+
+        assert!(!has_influence.is_empty());
+        assert!(!influenced.is_empty());
+        assert!(!no_influence.is_empty());
+
+        assert!(has_influence.influences_ctrl(&influenced));
+        assert!(!no_influence.influences_ctrl(&influenced));
     });
 }

--- a/crates/paralegal-flow/tests/marker_tests.rs
+++ b/crates/paralegal-flow/tests/marker_tests.rs
@@ -3,7 +3,7 @@
 #[macro_use]
 extern crate lazy_static;
 
-use paralegal_flow::{define_flow_test_template, test_utils::*};
+use paralegal_flow::{define_flow_test_template, inline_test, test_utils::*};
 use paralegal_spdg::{Identifier, InstructionKind};
 
 const TEST_CRATE_NAME: &str = "tests/marker-tests";
@@ -210,3 +210,45 @@ define_test!(typed_input_zst: ctrl -> {
         })
     }))
 });
+
+#[test]
+fn no_overtaint_from_sibling_markers() {
+    inline_test! {
+        #[paralegal_flow::marker(marked)]
+        struct Marked;
+
+        struct Parent {
+            marked: Marked,
+            unmarked: u32,
+        }
+
+        #[paralegal_flow::marker(sink, arguments = [0])]
+        fn reached<T>(_: T) {}
+
+        #[paralegal_flow::marker(sink_2, arguments = [0])]
+        fn reached_2<T>(_: T) {}
+
+        fn main(parent: Parent) {
+            reached(parent.unmarked);
+            reached_2(parent.marked);
+        }
+    }
+    .check_ctrl(|ctrl| {
+        let src = ctrl.marked("marked");
+        let reached = ctrl.marked("sink");
+        let reached_2 = ctrl.marked("sink_2");
+        println!("{:?}", ctrl.spdg().type_assigns);
+        println!("{:?}", ctrl.spdg().markers);
+        assert!(!src.is_empty());
+        assert!(!reached.is_empty());
+        assert!(!reached_2.is_empty());
+        for n in src.nodes() {
+            assert!(
+                !reached.nodes().contains(n),
+                "{n:?} is marked both `sink` and `marked`"
+            );
+        }
+        assert!(!src.flows_to_data(&reached));
+        assert!(src.flows_to_data(&reached_2));
+    });
+}

--- a/crates/paralegal-flow/tests/marker_tests.rs
+++ b/crates/paralegal-flow/tests/marker_tests.rs
@@ -191,10 +191,12 @@ define_test!(wrapping_typed_input: ctrl -> {
 
 define_test!(typed_input: ctrl -> {
     let marker = Identifier::new_intern("marked");
-    assert!(ctrl.spdg().arguments.iter().any(|node| {
+    let tyinf = dbg!(&ctrl.graph().desc.type_info);
+    dbg!(&ctrl.spdg().type_assigns);
+    assert!(dbg!(&ctrl.spdg().arguments).iter().any(|node| {
         let ts = ctrl.spdg().node_types(*node);
         dbg!(ts).iter().any(|t| {
-            ctrl.graph().desc.type_info[t].markers.contains(&marker)
+            tyinf[t].markers.contains(&marker)
         })
     }))
 });

--- a/crates/paralegal-spdg/src/dot.rs
+++ b/crates/paralegal-spdg/src/dot.rs
@@ -193,6 +193,18 @@ pub fn dump<W: std::io::Write>(spdg: &ProgramDescription, out: W) -> std::io::Re
     dump_for_selection(spdg, out, |_| true)
 }
 
+pub fn dump_all_separate<P: AsRef<std::path::Path>>(
+    spdg: &ProgramDescription,
+    file_name_schema: impl Fn(&[crate::Identifier]) -> P,
+) -> std::io::Result<()> {
+    for (_, ctrl) in &spdg.controllers {
+        let path = file_name_schema(&ctrl.path);
+        let out = std::fs::File::create(path)?;
+        dump_for_selection(spdg, out, |i| i == ctrl.id)?
+    }
+    Ok(())
+}
+
 /// Dump the SPDG for one select controller in dot format
 pub fn dump_for_controller(
     spdg: &ProgramDescription,

--- a/crates/paralegal-spdg/src/dot.rs
+++ b/crates/paralegal-spdg/src/dot.rs
@@ -105,6 +105,19 @@ impl<'a> dot::Labeller<'a, CallString, GlobalEdge> for DotPrintableProgramDescri
         Some(LabelText::LabelStr("record".into()))
     }
 
+    fn edge_label(&'a self, e: &GlobalEdge) -> LabelText<'a> {
+        LabelText::LabelStr(
+            self.format_call_string(
+                self.spdg.controllers[&e.controller_id]
+                    .graph
+                    .edge_weight(e.index)
+                    .unwrap()
+                    .at,
+            )
+            .into(),
+        )
+    }
+
     fn node_label(&'a self, n: &CallString) -> LabelText<'a> {
         let (ctrl_id, nodes) = &self.call_sites[n];
         let ctrl = &self.spdg.controllers[ctrl_id];

--- a/crates/paralegal-spdg/src/dot.rs
+++ b/crates/paralegal-spdg/src/dot.rs
@@ -206,11 +206,13 @@ pub fn dump<W: std::io::Write>(spdg: &ProgramDescription, out: W) -> std::io::Re
     dump_for_selection(spdg, out, |_| true)
 }
 
+/// Dump all PDGs, each in a separate dot file, with the naming schema provided
+/// by the supplied function
 pub fn dump_all_separate<P: AsRef<std::path::Path>>(
     spdg: &ProgramDescription,
     file_name_schema: impl Fn(&[crate::Identifier]) -> P,
 ) -> std::io::Result<()> {
-    for (_, ctrl) in &spdg.controllers {
+    for ctrl in spdg.controllers.values() {
         let path = file_name_schema(&ctrl.path);
         let out = std::fs::File::create(path)?;
         dump_for_selection(spdg, out, |i| i == ctrl.id)?

--- a/crates/paralegal-spdg/src/lib.rs
+++ b/crates/paralegal-spdg/src/lib.rs
@@ -874,7 +874,7 @@ impl GlobalEdge {
 }
 
 /// Node metadata in the [`SPDGImpl`]
-#[derive(Clone, Debug, Serialize, Deserialize, Allocative)]
+#[derive(Clone, Debug, Serialize, Deserialize, Allocative, PartialEq, Eq, Hash)]
 pub struct NodeInfo {
     /// Location of the node in the call stack
     pub at: CallString,

--- a/crates/paralegal-spdg/src/lib.rs
+++ b/crates/paralegal-spdg/src/lib.rs
@@ -882,6 +882,9 @@ pub struct NodeInfo {
     pub description: String,
     /// Span information for this node
     pub span: Span,
+    /// The local variable this node references. This is an MIR implementation
+    /// detail and should not be relied upon.
+    pub local: u32,
 }
 
 impl Display for NodeInfo {

--- a/crates/paralegal-spdg/src/lib.rs
+++ b/crates/paralegal-spdg/src/lib.rs
@@ -178,6 +178,12 @@ pub struct DefInfo {
 /// Provides a way to format rust paths
 pub struct DisplayPath<'a>(&'a [Identifier]);
 
+impl std::fmt::Debug for DisplayPath<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
 impl Display for DisplayPath<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write_sep(f, "::", self.0, Display::fmt)

--- a/crates/paralegal-spdg/src/utils.rs
+++ b/crates/paralegal-spdg/src/utils.rs
@@ -3,29 +3,7 @@
 use std::fmt;
 use std::fmt::{Display, Formatter, Write};
 
-/// Write all elements from `it` into the formatter `fmt` using `f`, separating
-/// them with `sep`
-pub fn write_sep<
-    E,
-    I: IntoIterator<Item = E>,
-    F: FnMut(E, &mut fmt::Formatter<'_>) -> fmt::Result,
->(
-    fmt: &mut fmt::Formatter<'_>,
-    sep: &str,
-    it: I,
-    mut f: F,
-) -> fmt::Result {
-    let mut first = true;
-    for e in it {
-        if first {
-            first = false;
-        } else {
-            fmt.write_str(sep)?;
-        }
-        f(e, fmt)?;
-    }
-    Ok(())
-}
+pub use flowistry_pdg::utils::write_sep;
 
 /// Has a [`Display`] implementation if the elements of the iterator inside have
 /// one. This will render them surrounded by `[` brackets and separated by `, `

--- a/crates/paralegal-spdg/src/utils.rs
+++ b/crates/paralegal-spdg/src/utils.rs
@@ -36,8 +36,10 @@ pub struct DisplayList<I> {
 }
 
 /// Display this iterator as a list
-pub fn display_list<I>(iter: I) -> DisplayList<I> {
-    DisplayList { iter }
+pub fn display_list<I: IntoIterator>(iter: I) -> DisplayList<<I as IntoIterator>::IntoIter> {
+    DisplayList {
+        iter: iter.into_iter(),
+    }
 }
 
 impl<E: Display, I: IntoIterator<Item = E> + Clone> Display for DisplayList<I> {


### PR DESCRIPTION
## What Changed?

Marker assignment for nodes is now determined while the PDG is assembled. This also eliminates the intermediate `DepGraph`.

`async` analysis entry points now also correctly map their arguments.

As a minor change when using the `spdg` dump option Paralegal now writes the graphs to `target/paralegal-dump/graphs` and dump a separate graph for each entry point.

Also fixed a marker overtaint issue where siblings would mark each other.

## Why Does It Need To?

Improves the precision of generics resolution for marker determination purposes. The marker assignment routines now use the same resolved generics as the graph assembly, instead of some hacky reproduction.

## Checklist

- [x] Add test cases for argument connections in top-level async functions
- [x] Test/fix assignment of markers to top-level async function arguments
- [x] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [x] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [x] Documentation in Notion has been updated
- [x] Tests for new behaviors are provided
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.