### PR TITLE
Fix the documentation build again

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,14 +23,12 @@ jobs:
         git config --local user.name "github-actions[bot]"
     - name: Install cargo-make
       run: rustup run stable cargo install --force --debug cargo-make
-    - name: Prepare
+    - name: Build and assemble docs
+      env:
+        RUSTC_DOCS_URL: https://brownsys.github.io/paralegal/compiler/
       run: |
-        cargo doc --document-private-items
-        mkdir docs
-        cp -R target/doc docs/libs
+        cargo make assemble-deploy-docs
         rm -R .github
-    - name: Copy rustc docs and index page
-      run: cargo make populate-doc-dir
     - name: Commit Doc Generation
       run: |
         git add docs

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -244,6 +244,52 @@ mv doc-src/index.html docs
 mv ${source_path} docs/compiler
 '''
 
+[tasks.build-public-docs]
+description = """\
+Build cargo docs with rustdoc links to the matching rustc-docs.
+
+Locally the links resolve via `file://` to the system-installed rustc-docs, so
+you can open `target/doc/` in a browser and follow links into rustc internals.
+CI overrides `RUSTC_DOCS_URL` so the links point at the bundled compiler docs
+shipped alongside the deployed site.
+"""
+dependencies = ["get-rustc-docs"]
+script_runner = "bash"
+script = '''
+set -e
+shopt -s nullglob
+rustc_doc_dir="$(rustc --print sysroot)/share/doc/rust/html/rustc"
+base_url="$RUSTC_DOCS_URL"
+if [ -z "$base_url" ]; then
+  base_url="file://$rustc_doc_dir/"
+fi
+# rustdoc appends `<crate>/<path>.html` to the URL, so it needs to be the
+# parent dir of the per-crate docs (and to end in `/`).
+flags=""
+for d in "$rustc_doc_dir"/*/; do
+  c="$(basename "$d")"
+  flags="$flags --extern-html-root-url $c=$base_url"
+done
+RUSTDOCFLAGS="$flags" cargo doc --document-private-items
+'''
+
+[tasks.assemble-deploy-docs]
+description = """\
+Build local docs with rustc-doc links and assemble `docs/` ready to deploy.
+
+Used by the docs CI job. Running locally is rarely useful; for browsing
+`target/doc/` use `build-public-docs` instead.
+"""
+# The shared `get-rustc-docs` dep runs once (cargo-make caches deps within an
+# invocation), so `populate-doc-dir`'s `mv` of the rustc-docs into
+# docs/compiler still finds them after `build-public-docs` enumerated them.
+dependencies = ["build-public-docs", "populate-doc-dir"]
+script_runner = "bash"
+script = '''
+set -e
+cp -R target/doc docs/libs
+'''
+
 [tasks.get-rustc-docs]
 command = "rustup"
 args = ["component", "add", "rustc-docs"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -238,7 +238,7 @@ exec --fail-on-error %{COMMAND} %{COMMAND_ARGS}
 dependencies = ["get-rustc-docs"]
 script_runner = "@duckscript"
 script = '''
-source_path = concat ${RUSTUP_HOME} /toolchains/ ${RUSTUP_TOOLCHAIN} /share/doc/rust/html/rustc
+source_path = concat ${RUSTUP_HOME} /toolchains/ ${RUSTUP_TOOLCHAIN} /share/doc/rust/html/rustc-docs
 mkdir docs
 mv doc-src/index.html docs
 mv ${source_path} docs/compiler
@@ -258,14 +258,15 @@ script_runner = "bash"
 script = '''
 set -e
 shopt -s nullglob
-rustc_doc_dir="$(rustc --print sysroot)/share/doc/rust/html/rustc"
+rustc_doc_dir="$(rustc --print sysroot)/share/doc/rust/html/rustc-docs"
 base_url="$RUSTC_DOCS_URL"
 if [ -z "$base_url" ]; then
   base_url="file://$rustc_doc_dir/"
 fi
 # rustdoc appends `<crate>/<path>.html` to the URL, so it needs to be the
 # parent dir of the per-crate docs (and to end in `/`).
-flags=""
+# `--extern-html-root-url` is gated behind -Z unstable-options.
+flags="-Z unstable-options"
 for d in "$rustc_doc_dir"/*/; do
   c="$(basename "$d")"
   flags="$flags --extern-html-root-url $c=$base_url"
@@ -296,8 +297,12 @@ args = ["component", "add", "rustc-docs"]
 dependencies = ["clean-rustc-docs-location"]
 
 [tasks.clean-rustc-docs-location]
-command = "rm"
-args = [
-    "-rf",
-    "${RUSTUP_HOME}/toolchains/${RUSTUP_TOOLCHAIN}/share/doc/rust/html/rustc",
-]
+description = "Uninstall rustc-docs so a follow-up `component add` actually re-extracts."
+# rustup tracks installed components via its manifest, not filesystem state.
+# A bare `rm -rf` of the docs dir leaves the manifest saying "installed", so
+# `rustup component add rustc-docs` no-ops and never re-extracts the files.
+# Going through `component remove` keeps rustup's view in sync with the disk.
+script_runner = "bash"
+script = '''
+rustup component remove rustc-docs 2>/dev/null || true
+'''

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -240,8 +240,10 @@ script_runner = "@duckscript"
 script = '''
 source_path = concat ${RUSTUP_HOME} /toolchains/ ${RUSTUP_TOOLCHAIN} /share/doc/rust/html/rustc-docs
 mkdir docs
-mv doc-src/index.html docs
-mv ${source_path} docs/compiler
+# Delegate to the shell `mv` instead of duckscript's, which is just
+# rename(2) and fails when ~/.rustup and the repo are on different mounts.
+exec --fail-on-error mv doc-src/index.html docs
+exec --fail-on-error mv ${source_path} docs/compiler
 '''
 
 [tasks.build-public-docs]
@@ -299,10 +301,14 @@ dependencies = ["clean-rustc-docs-location"]
 [tasks.clean-rustc-docs-location]
 description = "Uninstall rustc-docs so a follow-up `component add` actually re-extracts."
 # rustup tracks installed components via its manifest, not filesystem state.
-# A bare `rm -rf` of the docs dir leaves the manifest saying "installed", so
-# `rustup component add rustc-docs` no-ops and never re-extracts the files.
-# Going through `component remove` keeps rustup's view in sync with the disk.
+# A bare `rm -rf` leaves the manifest saying "installed", so the next
+# `component add` no-ops. Two more wrinkles: if the docs dir is missing
+# (e.g. moved by an earlier `populate-doc-dir`), `component remove` errors
+# trying to delete files that aren't there; if the component was never
+# installed, `remove` errors too. Recreate an empty dir to satisfy the
+# first case, and suppress the error from the second.
 script_runner = "bash"
 script = '''
+mkdir -p "$(rustc --print sysroot)/share/doc/rust/html/rustc-docs"
 rustup component remove rustc-docs 2>/dev/null || true
 '''

--- a/crates/paralegal-flow/src/lib.rs
+++ b/crates/paralegal-flow/src/lib.rs
@@ -4,6 +4,7 @@
 //! being able to reference the same code in the two executables `paralegal_flow` and
 //! `cargo-paralegal-flow` (a structure suggested by [rustc_plugin]).
 #![feature(rustc_private, min_specialization)]
+#![recursion_limit = "256"]
 
 extern crate rustc_abi;
 extern crate rustc_arena;


### PR DESCRIPTION
## What Changed?

Add a simple fix to hopefully make the documentation command work again.

Also attempts to fix the interlinking of compiler and paralegal library docs

## Why Does It Need To?

Doc flow is broken

## Checklist

- [ ] Above description has been filled out so that upon quash merge we have a
  good record of what changed.
- [ ] New functions, methods, types are documented. Old documentation is updated
  if necessary
- [ ] Documentation in Notion has been updated
- [ ] Tests for new behaviors are provided
  - [ ] New test suites (if any) ave been added to the CI tests (in
    `.github/workflows/rust.yml`) either as compiler test or integration test.
    *Or* justification for their omission from CI has been provided in this PR
    description.