### PR TITLE
Add DriverExtension hook for embedding paralegal as a library

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -50,6 +50,14 @@ pub struct ClapArgs {
     /// for `cargo` when tools expect `--message-format=json` output.
     #[clap(long)]
     pub forward_json: bool,
+    /// Drive the wrapped compile as `cargo build` instead of the default
+    /// `cargo check`. Codegen runs after the analyzer's `pre_pdg` /
+    /// `after_analysis` hooks (both return `Compilation::Continue`), so any
+    /// MIR rewrites are picked up by codegen. Use this when an embedder
+    /// (e.g. haven) wants the rewritten binaries as build artifacts, not
+    /// just the analysis output.
+    #[clap(long)]
+    pub build: bool,
     #[clap(last = true)]
     pub cargo_args: Vec<String>,
 }
@@ -66,6 +74,9 @@ impl ClapArgs {
         self.relaxed.hash(hasher);
         self.target.hash(hasher);
         self.result_path.hash(hasher);
+        // `--build` vs default `cargo check` produce different artifacts;
+        // keep their caches disjoint.
+        self.build.hash(hasher);
         config_hash_for_file(self.marker_control.external_annotations().as_ref(), hasher);
     }
 
@@ -199,5 +210,118 @@ impl MarkerControl {
 
     pub fn elide_on_whitelist_markers(&self) -> bool {
         self.elide_on_whitelist_markers
+    }
+}
+
+/// Rustc-wrapper boilerplate shared by `paralegal-flow-impl` and embedders
+/// that link the analyzer as a library (e.g. `haven-driver`).
+///
+/// What it does, in order:
+///
+/// 1. Parses `--version`/`-V`/`-vV`/`--verbose` out of argv. If a version
+///    probe is requested, prints the (possibly spoofed) version string and
+///    calls [`std::process::exit(0)`]. By default the `-nightly` suffix is
+///    stripped — build scripts otherwise turn on unstable features that
+///    don't survive paralegal's pinned-toolchain build. Setting
+///    `PARALEGAL_USE_REAL_RUSTC_VERSION=1` disables the spoof for debugging.
+/// 2. Strips the [`EXEC_HASH_ARG`] pair injected by `cargo-paralegal-flow`
+///    (used only to bust cargo's incremental cache across analyzer configs).
+/// 3. Detects `RUSTC_WRAPPER` invocation mode — cargo prepends `rustc` as
+///    `argv[1]` — and removes that arg so the remaining args match a plain
+///    rustc invocation.
+/// 4. Appends `--sysroot <sysroot_path>` so the analyzer-linked binary uses
+///    the toolchain it was built against rather than whatever cargo picked.
+///
+/// `real_long_version`, `host`, and `sysroot_path` are typically baked into
+/// the calling binary at build time via `env!()` of `RUSTC_LONG_VERSION`,
+/// `HOST`, and `SYSROOT_PATH` (see paralegal's `plugin/build.rs`).
+pub fn prepare_compiler_args(
+    real_long_version: &str,
+    host: &str,
+    sysroot_path: &str,
+) -> Vec<String> {
+    let mut args: Vec<String> = std::env::args().collect();
+    let version_args = VersionArgs::parse(args.iter());
+
+    let use_real_version = matches!(
+        std::env::var("PARALEGAL_USE_REAL_RUSTC_VERSION"),
+        Ok(v) if v == "1" || v.eq_ignore_ascii_case("true")
+    );
+    let long_version_owned;
+    let long_version: &str = if use_real_version {
+        real_long_version
+    } else {
+        // Build scripts on nightly often opt into unstable features that
+        // paralegal's pinned toolchain can't honour during analysis.
+        long_version_owned = real_long_version.replace("-nightly", "");
+        &long_version_owned
+    };
+
+    if version_args.version {
+        let unescaped = long_version.replace("\\n", "\n");
+        if version_args.verbose {
+            print!("{}", unescaped.replace("no-host-defined", host));
+        } else {
+            let short = unescaped
+                .lines()
+                .next()
+                .expect("Expected at least one line in version string");
+            println!("{short}");
+        }
+        std::process::exit(0);
+    }
+
+    if let Some(idx) = args.iter().position(|a| a == EXEC_HASH_ARG) {
+        args.remove(idx);
+        // EXEC_HASH_ARG's payload follows it; remove that too.
+        args.remove(idx);
+    }
+
+    let wrapper_mode =
+        args.get(1).map(Path::new).and_then(Path::file_stem) == Some("rustc".as_ref());
+    if wrapper_mode {
+        args.remove(1);
+    }
+
+    args.extend(["--sysroot".into(), sysroot_path.to_owned()]);
+    args
+}
+
+#[derive(Default)]
+struct VersionArgs {
+    verbose: bool,
+    version: bool,
+}
+
+impl VersionArgs {
+    fn parse(args: impl IntoIterator<Item = impl AsRef<str>>) -> Self {
+        let mut v = Self::default();
+        for a in args {
+            v.consume(a.as_ref());
+        }
+        v
+    }
+
+    fn consume(&mut self, a: &str) {
+        let mut chars = a.chars();
+        if chars.next() != Some('-') {
+            return;
+        }
+        match chars.next() {
+            Some('-') => match &a[2..] {
+                "verbose" => self.verbose = true,
+                "version" => self.version = true,
+                _ => {}
+            },
+            second => {
+                for c in second.into_iter().chain(chars) {
+                    match c {
+                        'V' => self.version = true,
+                        'v' => self.verbose = true,
+                        _ => {}
+                    }
+                }
+            }
+        }
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -24,6 +24,12 @@ pub const CARGO_ENCODED_RUSTFLAGS: &str = "CARGO_ENCODED_RUSTFLAGS";
 /// is `cargo-paralegal-flow` itself, which dispatches on argv[0] (see [`main`]).
 const WRAPPER_SHIM_NAME: &str = "paralegal-flow";
 
+/// Env var; when set, overrides the path to the rustc_driver-linked analyzer
+/// binary that the wrapper-shim execs for real compiles. Defaults to the
+/// sibling `paralegal-flow-impl` next to this binary. Used by embedders like
+/// haven that ship their own analyzer binary built on top of `paralegal_flow`.
+const IMPL_BIN_OVERRIDE_ENV: &str = "PARALEGAL_IMPL_BIN";
+
 /// File-name of the actual rustc_driver-linked analyzer binary that the shim
 /// hands real compile invocations to.
 const ANALYZER_IMPL_NAME: &str = "paralegal-flow-impl";
@@ -84,6 +90,12 @@ fn cargo_orchestrator_main() -> anyhow::Result<()> {
     args.hash_config(&mut hasher);
     config_hash_for_file(std::env::current_exe().ok(), &mut hasher);
     config_hash_for_file(Some(&rustc_wrapper_bin), &mut hasher);
+    // If embedder swaps the impl binary (e.g. haven-driver), mix its identity
+    // into the build hash so artifacts compiled under different analyzers
+    // don't get reused.
+    if let Some(p) = std::env::var_os(IMPL_BIN_OVERRIDE_ENV) {
+        config_hash_for_file(Some(Path::new(&p)), &mut hasher);
+    }
 
     let exec_hash = hasher.finish();
 
@@ -295,8 +307,13 @@ fn launcher_main() -> anyhow::Result<()> {
     // convention so paralegal-flow-impl's own argv-parsing (`wrapper_mode`
     // detection in crates/plugin/src/main.rs) still strips the rustc-path
     // arg before invoking rustc_driver.
-    let exe = std::env::current_exe().context("locating current executable")?;
-    let impl_path = exe.with_file_name(ANALYZER_IMPL_NAME);
+    let impl_path = match std::env::var_os(IMPL_BIN_OVERRIDE_ENV) {
+        Some(p) => PathBuf::from(p),
+        None => {
+            let exe = std::env::current_exe().context("locating current executable")?;
+            exe.with_file_name(ANALYZER_IMPL_NAME)
+        }
+    };
     let mut impl_argv: Vec<OsString> = Vec::with_capacity(rest.len() + 1);
     impl_argv.push(rustc_path);
     impl_argv.extend(rest);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -112,8 +112,9 @@ fn cargo_orchestrator_main() -> anyhow::Result<()> {
         .other_options(["--offline".into()])
         .exec()?;
 
+    let cargo_subcommand = if args.build { "build" } else { "check" };
     let mut cmd = Command::new(&cargo);
-    cmd.args(["check", "--message-format=json"]) // or "build"
+    cmd.args([cargo_subcommand, "--message-format=json"])
         .arg("--target-dir")
         .arg(metadata.target_directory.join("paralegal"))
         .args(args.cargo_args.iter())

--- a/crates/plugin/src/args.rs
+++ b/crates/plugin/src/args.rs
@@ -75,6 +75,9 @@ impl TryFrom<ClapArgs> for Args {
             strict,
             build_config: _,
             forward_json: _,
+            // Only acted on by `cargo-paralegal-flow`'s orchestrator, before
+            // `PARALEGAL_ARGS` is serialised — the analyzer never reads it.
+            build: _,
         } = value;
         if relaxed {
             eprintln!(

--- a/crates/plugin/src/discover.rs
+++ b/crates/plugin/src/discover.rs
@@ -16,7 +16,7 @@ use rustc_hir::{
     def_id::LocalDefId,
     intravisit::{self, FnKind},
 };
-use rustc_middle::{hir::nested_filter::OnlyBodies, ty::TyCtxt};
+use rustc_middle::hir::nested_filter::OnlyBodies;
 use rustc_span::{Span, Symbol, symbol::Ident};
 use tracing::trace;
 
@@ -31,10 +31,10 @@ pub type AttrMatchT = Vec<Symbol>;
 /// actual analysis. All of this is conveniently encapsulated in the
 /// [`Self::run`] method.
 pub struct CollectingVisitor<'tcx> {
-    /// Reference to rust compiler queries.
-    pub tcx: TyCtxt<'tcx>,
-    /// Command line arguments.
-    pub opts: &'static crate::Args,
+    /// Compilation context shared with the analyzer. Carries `tcx`, `opts`,
+    /// the body cache, and the marker DB so we don't re-initialise any of
+    /// those when transitioning into the generator.
+    pctx: Pctx<'tcx>,
     /// Functions that are annotated with `#[paralegal_flow::analyze]`. For these we will
     /// later perform the analysis
     pub functions_to_analyze: Vec<FnToAnalyze>,
@@ -61,7 +61,9 @@ impl FnToAnalyze {
 }
 
 impl<'tcx> CollectingVisitor<'tcx> {
-    pub(crate) fn new(tcx: TyCtxt<'tcx>, opts: &'static crate::Args, stats: Stats) -> Self {
+    pub(crate) fn new(pctx: Pctx<'tcx>, stats: Stats) -> Self {
+        let tcx = pctx.tcx();
+        let opts = pctx.opts();
         let functions_to_analyze = opts
             .anactrl()
             .selected_targets()
@@ -79,8 +81,7 @@ impl<'tcx> CollectingVisitor<'tcx> {
             })
             .collect();
         Self {
-            tcx,
-            opts,
+            pctx,
             functions_to_analyze,
             stats,
             analyze_marker: sym_vec!["paralegal_flow", "analyze"],
@@ -90,26 +91,31 @@ impl<'tcx> CollectingVisitor<'tcx> {
     /// After running the discovery with `visit_all_item_likes_in_crate`, create
     /// the read-only [`SPDGGenerator`] upon which the analysis will run.
     fn into_generator(self) -> SPDGGenerator<'tcx> {
-        let ctx = Pctx::new(self.tcx, self.opts);
-        let inline_judge = InlineJudge::new(ctx.clone());
-        SPDGGenerator::new(ctx, inline_judge, self.stats, self.functions_to_analyze)
+        let inline_judge = InlineJudge::new(self.pctx.clone());
+        SPDGGenerator::new(
+            self.pctx,
+            inline_judge,
+            self.stats,
+            self.functions_to_analyze,
+        )
     }
 
     /// Driver function. Performs the data collection via visit, then calls
     /// [`Self::analyze`] to construct the Forge friendly description of all
     /// endpoints.
     pub fn run(mut self) -> SPDGGenerator<'tcx> {
-        let tcx = self.tcx;
+        let tcx = self.pctx.tcx();
         tcx.hir_visit_all_item_likes_in_crate(&mut self);
         self.into_generator()
     }
 
     /// Does the function named by this id have the `paralegal_flow::analyze` annotation
     fn should_analyze_function(&self, ident: LocalDefId) -> bool {
-        let attrs = self.tcx.hir_attrs(self.tcx.local_def_id_to_hir_id(ident));
+        let tcx = self.pctx.tcx();
+        let attrs = tcx.hir_attrs(tcx.local_def_id_to_hir_id(ident));
         let should_analyze = attrs.iter().any(|a| a.path_matches(&self.analyze_marker));
         trace!(
-            name = self.tcx.def_path_str(ident),
+            name = tcx.def_path_str(ident),
             should_analyze,
             ?attrs,
             "discovering function"
@@ -122,7 +128,7 @@ impl<'tcx> intravisit::Visitor<'tcx> for CollectingVisitor<'tcx> {
     type NestedFilter = OnlyBodies;
 
     fn maybe_tcx(&mut self) -> Self::MaybeTyCtxt {
-        self.tcx
+        self.pctx.tcx()
     }
 
     /// Finds the functions that have been marked as targets.

--- a/crates/plugin/src/extension.rs
+++ b/crates/plugin/src/extension.rs
@@ -1,0 +1,45 @@
+//! Hook points for embedding paralegal as a library inside another rustc
+//! driver (e.g. haven). An extension's [`pre_pdg`] hook runs after MIR is
+//! borrow-checked but before paralegal consumes it for PDG construction.
+//!
+//! [`pre_pdg`]: DriverExtension::pre_pdg
+//!
+//! Extensions are plugged in via [`crate::run_with_extension`]. The standalone
+//! `paralegal_flow` binary uses [`NoopExtension`].
+//!
+//! The interface is deliberately minimal: one hook, with [`MarkerCtx`] exposed
+//! so extensions can query side-effect/safety markers without re-running
+//! marker discovery. Add further hooks only when a concrete consumer needs
+//! them.
+//!
+//! Stability: this is a paralegal-internal interface tracked alongside the
+//! paralegal-pinned nightly. It is not a stable plugin ABI.
+use rustc_middle::ty::TyCtxt;
+
+use crate::MarkerCtx;
+
+pub trait DriverExtension: Send {
+    /// Runs after MIR borrow-check completes and `MarkerCtx` is populated,
+    /// before paralegal starts PDG construction. Implementations may mutate
+    /// MIR via the steal/return pattern on the relevant rustc queries.
+    ///
+    /// Always fires on the analyzed crate. Whether it fires on dependency
+    /// crates that are compiled-and-dumped is gated by
+    /// [`Self::requires_dependency_markers`] — constructing `MarkerCtx` for
+    /// every dependency is non-trivial work that paralegal otherwise skips.
+    fn pre_pdg<'tcx>(&mut self, _tcx: TyCtxt<'tcx>, _markers: &MarkerCtx<'tcx>) {}
+
+    /// If true, `pre_pdg` fires on dependency crates too (those handled by
+    /// [`crate::CrateHandling::CompileAndDump`]) and paralegal forces full
+    /// `MarkerDatabase::init` for them. Default `false` to preserve the
+    /// standalone paralegal cost profile when no real extension is loaded.
+    fn requires_dependency_markers(&self) -> bool {
+        false
+    }
+}
+
+/// Default extension used when paralegal runs standalone. All hooks are
+/// no-ops; `requires_dependency_markers` returns `false`.
+pub struct NoopExtension;
+
+impl DriverExtension for NoopExtension {}

--- a/crates/plugin/src/extension.rs
+++ b/crates/plugin/src/extension.rs
@@ -15,6 +15,8 @@
 //! Stability: this is a paralegal-internal interface tracked alongside the
 //! paralegal-pinned nightly. It is not a stable plugin ABI.
 use rustc_middle::ty::TyCtxt;
+use rustc_middle::util::Providers;
+use rustc_session::Session;
 
 use crate::MarkerCtx;
 
@@ -35,6 +37,19 @@ pub trait DriverExtension: Send {
     /// standalone paralegal cost profile when no real extension is loaded.
     fn requires_dependency_markers(&self) -> bool {
         false
+    }
+
+    /// Optional `fn` to layer on top of paralegal's own [`Providers`]
+    /// overrides during [`rustc_interface::Config`] setup. Paralegal installs
+    /// its own `mir_borrowck` wrapper first, then calls the extension's `fn`
+    /// (if any) so extensions can replace or further wrap the providers.
+    ///
+    /// Returns a plain `fn` rather than a closure because rustc's
+    /// `Config::override_queries` itself is `Option<fn(..)>`. Extensions that
+    /// need to thread per-invocation state must stash it in a `OnceLock` /
+    /// thread-local before `run_with_extension` is called.
+    fn query_providers(&self) -> Option<fn(&Session, &mut Providers)> {
+        None
     }
 }
 

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -64,6 +64,7 @@ pub mod constants;
 mod ctx;
 pub mod dbg;
 mod discover;
+pub mod extension;
 pub mod mir;
 pub mod source_access;
 mod stats;
@@ -83,6 +84,7 @@ use ann::dump_markers;
 pub use args::{AnalysisCtrl, Args, BuildConfig, DepConfig, DumpArgs};
 use cargo_paralegal_flow::{ClapArgs, Debugger};
 pub use ctx::Pctx;
+pub use extension::{DriverExtension, NoopExtension};
 use desc::utils::write_sep;
 
 pub const EXTRA_RUSTC_ARGS: &[&str] = &[
@@ -128,6 +130,7 @@ struct Callbacks {
     start: Instant,
     dump_stats: DumpStats,
     output_location: Option<PathBuf>,
+    extension: Box<dyn DriverExtension>,
 }
 
 struct NoopCallbacks;
@@ -141,7 +144,7 @@ impl FinalizingCallbacks for NoopCallbacks {
 }
 
 impl Callbacks {
-    pub fn new(opts: &'static Args) -> Self {
+    pub fn new(opts: &'static Args, extension: Box<dyn DriverExtension>) -> Self {
         Self {
             opts,
             stats: Default::default(),
@@ -150,6 +153,7 @@ impl Callbacks {
             start: Instant::now(),
             dump_stats: DumpStats::zero(),
             output_location: None,
+            extension,
         }
     }
 }
@@ -180,17 +184,28 @@ impl DumpStats {
 }
 
 struct DumpOnlyCallbacks {
+    /// Carried so `after_expansion` can construct a [`Pctx`] when the
+    /// extension opts in via `requires_dependency_markers`. Unused otherwise.
+    opts: &'static Args,
     time: DumpStats,
     start: Instant,
     output_location: Option<PathBuf>,
+    extension: Box<dyn DriverExtension>,
+    /// Captured at construction so the `after_expansion` hot path doesn't
+    /// re-dispatch through the extension trait just to check.
+    extension_wants_markers: bool,
 }
 
 impl DumpOnlyCallbacks {
-    fn new() -> Self {
+    fn new(opts: &'static Args, extension: Box<dyn DriverExtension>) -> Self {
+        let extension_wants_markers = extension.requires_dependency_markers();
         Self {
+            opts,
             time: DumpStats::zero(),
             start: Instant::now(),
             output_location: None,
+            extension,
+            extension_wants_markers,
         }
     }
 }
@@ -222,11 +237,22 @@ impl rustc_driver::Callbacks for DumpOnlyCallbacks {
         configure(config)
     }
 
-    fn after_expansion(
+    fn after_expansion<'tcx>(
         &mut self,
         _compiler: &rustc_interface::interface::Compiler,
-        tcx: TyCtxt<'_>,
+        tcx: TyCtxt<'tcx>,
     ) -> rustc_driver::Compilation {
+        // `MarkerDatabase::init` reads this crate's `.pmeta` from disk, so
+        // markers must be dumped before `Pctx::new` runs. `dump_mir_and_update_stats`
+        // below dumps them again as part of its bundled emission — that's
+        // idempotent and matches pre-refactor behavior.
+        if self.extension_wants_markers {
+            let dump_marker_start = Instant::now();
+            dump_markers(tcx);
+            self.time.dump_time += dump_marker_start.elapsed();
+            let pctx = Pctx::new(tcx, self.opts);
+            self.extension.pre_pdg(tcx, pctx.marker_ctx());
+        }
         dump_mir_and_update_stats(tcx, &mut self.time);
         self.output_location = Some(intermediate_out_dir(tcx, INTERMEDIATE_STAT_EXT));
         rustc_driver::Compilation::Continue
@@ -257,11 +283,22 @@ impl rustc_driver::Callbacks for Callbacks {
     fn after_expansion<'tcx>(
         &mut self,
         _compiler: &rustc_interface::interface::Compiler,
-        tcx: TyCtxt<'_>,
+        tcx: TyCtxt<'tcx>,
     ) -> rustc_driver::Compilation {
         self.stats
             .record_timed(TimedStat::Rustc, self.stats.elapsed());
-        let compilation = self.run_the_analyzer(tcx);
+        // `MarkerDatabase::init` (inside `Pctx::new`) loads every included
+        // crate's marker metadata from disk, including this crate's own
+        // `.pmeta`. So we must dump first, then construct Pctx.
+        let dump_marker_start = Instant::now();
+        dump_markers(tcx);
+        self.dump_stats.dump_time += dump_marker_start.elapsed();
+        // Share Pctx with both the extension hook and the analyzer below so
+        // `MarkerDatabase::init` runs only once per compilation. The
+        // extension may mutate MIR before the analyzer consumes it.
+        let pctx = Pctx::new(tcx, self.opts);
+        self.extension.pre_pdg(tcx, pctx.marker_ctx());
+        let compilation = self.run_the_analyzer(pctx);
         self.rustc_second_timer = Some(Instant::now());
         compilation
     }
@@ -307,15 +344,31 @@ impl FinalizingCallbacks for Callbacks {
 }
 
 impl Callbacks {
-    pub fn run_in_context_without_writing_stats(
+    /// In-process entry point used by `test_utils`. Dumps the local crate's
+    /// marker metadata, builds a fresh [`Pctx`], and delegates. Production
+    /// code shares a single `Pctx` with the extension hook and calls
+    /// [`Self::run_in_context_with_pctx`] directly instead.
+    #[cfg(feature = "test")]
+    pub fn run_in_context_without_writing_stats<'tcx>(
         &mut self,
-        tcx: TyCtxt<'_>,
+        tcx: TyCtxt<'tcx>,
     ) -> anyhow::Result<(ProgramDescription, AnalyzerStats)> {
         let dump_marker_start = Instant::now();
         dump_markers(tcx);
         self.dump_stats.dump_time += dump_marker_start.elapsed();
+        self.run_in_context_with_pctx(Pctx::new(tcx, self.opts))
+    }
+
+    /// Internal entry point used by the production path. Caller must have
+    /// already invoked `dump_markers(tcx)` before constructing `pctx`,
+    /// because `MarkerDatabase::init` reads `.pmeta` files from disk.
+    pub fn run_in_context_with_pctx<'tcx>(
+        &mut self,
+        pctx: Pctx<'tcx>,
+    ) -> anyhow::Result<(ProgramDescription, AnalyzerStats)> {
+        let tcx = pctx.tcx();
         tcx.dcx().abort_if_errors();
-        let vis = discover::CollectingVisitor::new(tcx, self.opts, self.stats.clone());
+        let vis = discover::CollectingVisitor::new(pctx, self.stats.clone());
         let mut generator = vis.run();
         let (desc, stats) = generator.analyze()?;
         info!(num_controllers = desc.controllers.len(), "All elems walked");
@@ -353,14 +406,15 @@ impl Callbacks {
         Ok((desc, stats))
     }
 
-    fn run_the_analyzer(&mut self, tcx: TyCtxt<'_>) -> rustc_driver::Compilation {
+    fn run_the_analyzer<'tcx>(&mut self, pctx: Pctx<'tcx>) -> rustc_driver::Compilation {
+        let tcx = pctx.tcx();
         (|| {
             assert!(
                 self.output_location
                     .replace(intermediate_out_dir(tcx, INTERMEDIATE_STAT_EXT))
                     .is_none()
             );
-            let (desc, mut stats) = self.run_in_context_without_writing_stats(tcx)?;
+            let (desc, mut stats) = self.run_in_context_with_pctx(pctx)?;
             self.stats.measure(TimedStat::Serialization, || {
                 desc.canonical_write(self.opts.result_path()).unwrap()
             });
@@ -465,16 +519,29 @@ fn how_to_handle_this_crate(plugin_args: &Args, compiler_args: &mut Vec<String>)
     info
 }
 
-pub fn run(mut compiler_args: Vec<String>, plugin_args: Args) -> Result<(), ErrorGuaranteed> {
+pub fn run(compiler_args: Vec<String>, plugin_args: Args) -> Result<(), ErrorGuaranteed> {
+    run_with_extension(compiler_args, plugin_args, Box::new(NoopExtension))
+}
+
+/// Same as [`run`] but with a [`DriverExtension`] that gets to mutate MIR
+/// before paralegal's PDG construction. Used by embedders like haven that
+/// need a pre-PDG hook.
+pub fn run_with_extension(
+    mut compiler_args: Vec<String>,
+    plugin_args: Args,
+    extension: Box<dyn DriverExtension>,
+) -> Result<(), ErrorGuaranteed> {
     let handling = how_to_handle_this_crate(&plugin_args, &mut compiler_args);
     debug!(?handling, "Crate handling");
     compiler_args.extend(EXTRA_RUSTC_ARGS.iter().copied().map(ToString::to_string));
-    let mut callbacks = match handling.handling {
-        CrateHandling::JustCompile => Box::new(NoopCallbacks) as Box<dyn FinalizingCallbacks>,
-        CrateHandling::CompileAndDump => Box::new(DumpOnlyCallbacks::new()),
+    // Leak unconditionally so both callback variants can take a `&'static
+    // Args`. The Analyze-only debugger setup below still needs to consult
+    // `opts` before we move into the match arm.
+    let opts: &'static Args = Box::leak(Box::new(plugin_args));
+    let mut callbacks: Box<dyn FinalizingCallbacks> = match handling.handling {
+        CrateHandling::JustCompile => Box::new(NoopCallbacks),
+        CrateHandling::CompileAndDump => Box::new(DumpOnlyCallbacks::new(opts, extension)),
         CrateHandling::Analyze => {
-            let opts = Box::leak(Box::new(plugin_args));
-
             const RERUN_VAR: &str = "RERUN_WITH_PROFILER";
             if let Ok(debugger) = std::env::var(RERUN_VAR) {
                 info!("Restarting with debugger '{debugger}'");
@@ -494,7 +561,7 @@ pub fn run(mut compiler_args: Vec<String>, plugin_args: Args) -> Result<(), Erro
                 attach_debugger(dbg)
             }
 
-            Box::new(Callbacks::new(opts))
+            Box::new(Callbacks::new(opts, extension))
         }
     };
 

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -37,6 +37,8 @@ use paralegal_pdg::{AnalyzerStats, FLOW_GRAPH_EXT, ProgramDescription, STAT_FILE
 
 use rustc_interface::Config;
 use rustc_middle::ty::TyCtxt;
+use rustc_middle::util::Providers;
+use rustc_session::Session;
 use rustc_span::ErrorGuaranteed;
 use tracing::{debug, error, info};
 
@@ -46,6 +48,7 @@ use std::{
     fs::File,
     io::BufWriter,
     path::PathBuf,
+    sync::OnceLock,
     time::{Duration, Instant},
 };
 
@@ -220,8 +223,21 @@ fn dump_mir_and_update_stats(tcx: TyCtxt, timer: &mut DumpStats) {
     timer.tycheck_time = tycheck_time;
 }
 
+/// Set by [`run_with_extension`] when the active [`DriverExtension`] returns
+/// `Some` from [`DriverExtension::query_providers`]. The override closure
+/// installed in [`configure`] reads it and layers the extension's providers
+/// on top of paralegal's own. `fn` (not `Fn`) because `Config::override_queries`
+/// is itself `Option<fn(..)>` — extensions stash any per-run state in their
+/// own statics.
+static EXTENSION_QUERY_PROVIDERS: OnceLock<fn(&Session, &mut Providers)> = OnceLock::new();
+
 fn configure(config: &mut Config) {
-    config.override_queries = Some(|_, providers| providers.queries.mir_borrowck = mir_borrowck);
+    config.override_queries = Some(|sess, providers| {
+        providers.queries.mir_borrowck = mir_borrowck;
+        if let Some(ext) = EXTENSION_QUERY_PROVIDERS.get() {
+            ext(sess, providers);
+        }
+    });
     assert_eq!(config.opts.unstable_opts.threads, 1);
     //config.opts.unstable_opts.polonius = Polonius::Next;
     // We don't care about emitting any lints. Users can get those when they
@@ -531,6 +547,14 @@ pub fn run_with_extension(
     plugin_args: Args,
     extension: Box<dyn DriverExtension>,
 ) -> Result<(), ErrorGuaranteed> {
+    // Snapshot the extension's provider overrides before any callback's
+    // `config()` hook fires — the override closure inside [`configure`] reads
+    // this OnceLock at compile time. Idempotent: second-and-later sets are
+    // discarded (matters only if a process ever runs multiple compilations,
+    // which paralegal currently doesn't).
+    if let Some(ext_providers) = extension.query_providers() {
+        let _ = EXTENSION_QUERY_PROVIDERS.set(ext_providers);
+    }
     let handling = how_to_handle_this_crate(&plugin_args, &mut compiler_args);
     debug!(?handling, "Crate handling");
     compiler_args.extend(EXTRA_RUSTC_ARGS.iter().copied().map(ToString::to_string));

--- a/crates/plugin/src/main.rs
+++ b/crates/plugin/src/main.rs
@@ -1,118 +1,18 @@
 #![feature(rustc_private)]
-use std::path::Path;
 
-use cargo_paralegal_flow::{ClapArgs, EXEC_HASH_ARG, PARALEGAL_ARGS};
+use cargo_paralegal_flow::{ClapArgs, PARALEGAL_ARGS, prepare_compiler_args};
 use paralegal_pdg::utils::setup_logging;
 use rustc_session::{EarlyDiagCtxt, config::ErrorOutputType};
-use tracing::debug;
 
 extern crate rustc_driver;
 extern crate rustc_session;
 
-#[derive(Default)]
-struct VersionArgs {
-    verbose: bool,
-    version: bool,
-}
-
-impl VersionArgs {
-    pub fn parse_args(args: impl IntoIterator<Item = impl AsRef<str>>) -> Self {
-        let mut version_args = Self::default();
-        version_args.handle_args(args);
-        version_args
-    }
-
-    fn handle_args(&mut self, a: impl IntoIterator<Item = impl AsRef<str>>) {
-        for i in a {
-            self.handle_arg(i.as_ref());
-        }
-    }
-
-    fn handle_arg(&mut self, a: &str) {
-        let mut chars = a.chars();
-        if chars.next() != Some('-') {
-            return;
-        }
-        let second = chars.next();
-        if second == Some('-') {
-            self.handle_long_arg(&a[2..]);
-        } else {
-            for c in second.into_iter().chain(chars) {
-                self.handle_short_arg(c);
-            }
-        }
-    }
-
-    fn handle_short_arg(&mut self, c: char) {
-        match c {
-            'V' => self.version = true,
-            'v' => self.verbose = true,
-            _ => (),
-        }
-    }
-
-    fn handle_long_arg(&mut self, s: &str) {
-        match s {
-            "verbose" => self.verbose = true,
-            "version" => self.version = true,
-            _ => (),
-        }
-    }
-}
-
 const REAL_LONG_VERSION: &str = env!("RUSTC_LONG_VERSION");
-
 const HOST: &str = env!("HOST");
-
-fn unescape_version(s: &str) -> String {
-    s.replace("\\n", "\n")
-}
 
 fn main() -> anyhow::Result<()> {
     setup_logging()?;
-    let use_real_version = matches!(std::env::var("PARALEGAL_USE_REAL_RUSTC_VERSION"), Ok(v) if v == "1" || v.eq_ignore_ascii_case("true"));
-    let mut args = std::env::args().collect::<Vec<_>>();
-    let version_args = VersionArgs::parse_args(args.iter());
-    let long_version = if use_real_version {
-        REAL_LONG_VERSION.to_string()
-    } else {
-        // We lie about being a nightly compiler, since build scripts often
-        // enable weird features and are much less stable for nightly compilers.
-        REAL_LONG_VERSION.replace("-nightly", "")
-    };
-    let unescaped = unescape_version(&long_version);
-    if version_args.version {
-        if version_args.verbose {
-            print!("{}", unescaped.replace("no-host-defined", HOST));
-        } else {
-            let short_version = &unescaped
-                .lines()
-                .next()
-                .expect("Expected at least one line in version string");
-            println!("{}", unescape_version(short_version));
-        }
-        std::process::exit(0);
-    }
-
-    debug!(?args);
-
-    if let Some((hash_check_arg, _)) = args.iter().enumerate().find(|elem| elem.1 == EXEC_HASH_ARG)
-    {
-        args.remove(hash_check_arg);
-        args.remove(hash_check_arg);
-    }
-
-    // Setting RUSTC_WRAPPER causes Cargo to pass 'rustc' as the first argument.
-    // We're invoking the compiler programmatically, so we ignore this
-    let wrapper_mode =
-        args.get(1).map(Path::new).and_then(Path::file_stem) == Some("rustc".as_ref());
-
-    if wrapper_mode {
-        // we still want to be able to invoke it normally though
-        args.remove(1);
-    }
-
-    args.extend(["--sysroot".into(), env!("SYSROOT_PATH").into()]);
+    let args = prepare_compiler_args(REAL_LONG_VERSION, HOST, env!("SYSROOT_PATH"));
 
     let parsed_plugin_args: ClapArgs = serde_json::from_str(&std::env::var(PARALEGAL_ARGS)?)?;
     let plugin_args: paralegal_flow::Args = parsed_plugin_args.try_into()?;

--- a/crates/plugin/src/test_utils.rs
+++ b/crates/plugin/src/test_utils.rs
@@ -10,7 +10,7 @@ use rustc_middle::ty::TyCtxt;
 use tracing::debug;
 
 use crate::{
-    Callbacks, EXTRA_RUSTC_ARGS, HashSet,
+    Callbacks, EXTRA_RUSTC_ARGS, HashSet, NoopExtension,
     ann::{db::AutoMarkers, dump_markers},
     desc::{Identifier, ProgramDescription},
     utils::Print,
@@ -567,7 +567,7 @@ impl InlineTestBuilder {
                 let args: &'static _ = Box::leak(Box::new(args));
                 dump_markers(result.tcx);
                 let tcx = result.tcx;
-                let (pdg, _) = Callbacks::new(args)
+                let (pdg, _) = Callbacks::new(args, Box::new(NoopExtension))
                     .run_in_context_without_writing_stats(tcx)
                     .unwrap();
                 let graph = PreFrg::from_description(pdg);


### PR DESCRIPTION
## Summary

Adds a `DriverExtension` trait and a `run_with_extension` entry point so external rustc drivers can plug into paralegal between borrow-check and PDG construction without forking. The motivating consumer is haven's planned MIR rewrite pass, which needs to mutate MIR before paralegal walks it.

- `DriverExtension::pre_pdg(tcx, &MarkerCtx)` fires after MIR borrow-check, before paralegal consumes MIR.
- `run_with_extension(args, plugin_args, Box<dyn DriverExtension>)`; existing `run` becomes sugar that passes a `NoopExtension`.
- `Pctx` is now built once at the top of `Callbacks::after_expansion` and shared with both the hook and the analyzer, collapsing the previous double `MarkerDatabase::init`.
- `DumpOnlyCallbacks` opts into the same hook for dependency crates only when the extension sets `requires_dependency_markers`, preserving the standalone paralegal cost profile.

## Notes for reviewers

The non-obvious ordering constraint surfaced by the cross-crate tests: `MarkerDatabase::init` reads each included crate's `.pmeta` from disk, including the local one. `dump_markers(tcx)` therefore has to run before `Pctx::new`. Both `after_expansion` paths now document that constraint in code, and the `run_in_context_with_pctx` helper expects callers to have already dumped.

Marked draft: opening this now to get directional feedback on the trait surface and the timing/ordering changes before haven starts depending on the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)