### PR TITLE
guide: compile the deletion policy, not the lemmy community policy

### DIFF
--- a/guide/deletion-policy/build.rs
+++ b/guide/deletion-policy/build.rs
@@ -1,7 +1,7 @@
 use std::{env, path::Path, process::Command};
 
 fn main() {
-    let p = Path::new("../../examples/policies/lemmy/community.txt");
+    let p = Path::new("policy.txt");
     println!("cargo:rerun-if-changed={}", p.display());
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let mut out_file = Path::new(&out_dir).join("policy.rs");


### PR DESCRIPTION
`deletion-policy/build.rs` compiled `examples/policies/lemmy/community.txt` instead of the example's own `deletion-policy/policy.txt`. That lemmy policy checks markers (`community`, `community_delete_check`, `community_ban_check`) that don't exist in `file-db-example`, so the shipped Step-by-Step example didn't reproduce the guide's walkthrough or its documented error output — anyone following the guide would hit a policy about markers they never defined.

The reference looks like a leftover from #179 (build.rs previously pointed at `policy.txt`). This points it back.

Verified end-to-end against the guide:
- as shipped (Image deletion commented out) → `error: Failed policy` … `failed because of file_db_example::Image`, matching the guide's expected output verbatim;
- with the Image deletion loop uncommented → `Policy succeeded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
